### PR TITLE
Add DST time tolerance

### DIFF
--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -217,6 +217,7 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">1</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_10">10</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_3">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_dst">3603</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_prompt">Last time of tolerance(Sec)</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_internal">Duplicate directory names exist at both internal storage source and destination.  Source and destination directory names must be different.</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_same_dir">Duplicate directory names exist at both source and destination.  Source and destination directory names must be different.</string>


### PR DESCRIPTION
When changing time DST (Day Light Saving Time), sdcard/FAT/ExFAT time is not encoded same as in NTFS/SMB shares.
When Day Light Time Saving changes, files are copied again because of 1h time shift.
Add tolerance to 3603 seconds for DST adjust time