### PR TITLE
Add option to ignore DST time difference

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3121,12 +3121,12 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_1));
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_3));
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_10));
-	adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_dst));
+        adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_dst));
 
         if (cv == 1) spinner.setSelection(0);
         else if (cv == 3) spinner.setSelection(1);
         else if (cv == 10) spinner.setSelection(2);
-	else if (cv == 3603) spinner.setSelection(3);
+        else if (cv == 3603) spinner.setSelection(3);
 
         adapter.notifyDataSetChanged();
     }

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3121,10 +3121,12 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_1));
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_3));
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_10));
+	adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_dst));
 
         if (cv == 1) spinner.setSelection(0);
         else if (cv == 3) spinner.setSelection(1);
         else if (cv == 10) spinner.setSelection(2);
+	else if (cv == 3603) spinner.setSelection(3);
 
         adapter.notifyDataSetChanged();
     }

--- a/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
@@ -215,6 +215,7 @@
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">1</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_10">10</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_3">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_dst">3603</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_prompt">最終更新時刻の差（秒）</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_internal">マスターフォルダーとターゲットフォルダーの両方が内部ストレージでディレクトリーが重複しています。どちらかを違うディレクトリーに変更してください。</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_same_dir">マスターフォルダーとターゲットフォルダーで同じディレクトリにアクセスします、どちらかのディレクトリを変更するかディレクトリフィルターを指定してください。</string>

--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -217,6 +217,7 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">1</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_10">10</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_3">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_dst">3603</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_prompt">Last time of tolerance(Sec)</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_internal">Duplicate directory names exist at both internal storage source and destination.  Source and destination directory names must be different.</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_same_dir">Duplicate directory names exist at both source and destination.  Source and destination directory names must be different.</string>


### PR DESCRIPTION
Add DST time tolerance
When changing time DST (Day Light Saving Time), sdcard/FAT/ExFAT time is not encoded same as in NTFS/SMB shares.
When Day Light Time Saving changes, files are copied again because of 1h time shift.
This fix adds tolerance to 3603 seconds for DST adjust time