### PR TITLE
Add option to ignore Day Light Saving Time

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3279,6 +3279,10 @@ public class SyncTaskEditor extends DialogFragment {
         ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(n_sti.isSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile());
         setCtvListenerForEditSyncTask(ctv_never_overwrite_target_file_newer_than_the_master_file, type, n_sti, dlg_msg);
 
+        final CheckedTextView ctv_ignore_dst_difference = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_ignore_dst_difference);
+        ctv_ignore_dst_difference.setChecked(n_sti.isSyncOptionIgnoreDstDifference());
+        setCtvListenerForEditSyncTask(ctv_ignore_dst_difference, type, n_sti, dlg_msg);
+
         final CheckedTextView ctv_edit_sync_task_option_ignore_unusable_character_used_directory_file_name = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ignore_unusable_character_used_directory_file_name);
         ctv_edit_sync_task_option_ignore_unusable_character_used_directory_file_name.setChecked(n_sti.isSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters());
         setCtvListenerForEditSyncTask(ctv_edit_sync_task_option_ignore_unusable_character_used_directory_file_name, type, n_sti, dlg_msg);
@@ -3605,10 +3609,13 @@ public class SyncTaskEditor extends DialogFragment {
         ctDeterminChangedFileByTime.setChecked(n_sti.isSyncOptionDifferentFileByTime());
         if (n_sti.isSyncOptionDifferentFileByTime()) {
             ctv_never_overwrite_target_file_newer_than_the_master_file.setEnabled(true);
+            ctv_ignore_dst_difference.setEnabled(true);
             CommonDialog.setViewEnabled(getActivity(), spinnerSyncDiffTimeValue, true);
         } else {
             ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
             ctv_never_overwrite_target_file_newer_than_the_master_file.setEnabled(false);
+            ctv_ignore_dst_difference.setChecked(false);
+            ctv_ignore_dst_difference.setEnabled(false);
             CommonDialog.setViewEnabled(getActivity(), spinnerSyncDiffTimeValue, false);
         }
         ctDeterminChangedFileByTime.setOnClickListener(new OnClickListener() {
@@ -3618,10 +3625,13 @@ public class SyncTaskEditor extends DialogFragment {
                 ((CheckedTextView) v).setChecked(isChecked);
                 if (isChecked) {
                     ctv_never_overwrite_target_file_newer_than_the_master_file.setEnabled(true);
+                    ctv_ignore_dst_difference.setEnabled(true);
                     CommonDialog.setViewEnabled(getActivity(), spinnerSyncDiffTimeValue, true);
                 } else {
                     ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
                     ctv_never_overwrite_target_file_newer_than_the_master_file.setEnabled(false);
+                    ctv_ignore_dst_difference.setChecked(false);
+                    ctv_ignore_dst_difference.setEnabled(false);
                     CommonDialog.setViewEnabled(getActivity(), spinnerSyncDiffTimeValue, false);
                 }
                 checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
@@ -4238,6 +4248,7 @@ public class SyncTaskEditor extends DialogFragment {
 
         final CheckedTextView ctv_task_sync_when_cahrging = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_sync_start_when_charging);
         final CheckedTextView ctv_never_overwrite_target_file_newer_than_the_master_file = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_never_overwrite_target_file_if_it_is_newer_than_the_master_file);
+        final CheckedTextView ctv_ignore_dst_difference = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_ignore_dst_difference);
         final CheckedTextView ctv_ignore_unusable_character_used_directory_file_name = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ignore_unusable_character_used_directory_file_name);
         final CheckedTextView ctv_do_not_use_rename_when_smb_file_write = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_do_mot_use_rename_when_smb_file_write);
 
@@ -4319,6 +4330,7 @@ public class SyncTaskEditor extends DialogFragment {
         nstli.setSyncOptionDifferentFileByTime(ctDeterminChangedFileByTime.isChecked());
 
         nstli.setSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile(ctv_never_overwrite_target_file_newer_than_the_master_file.isChecked());
+        nstli.setSyncOptionIgnoreDstDifference(ctv_ignore_dst_difference.isChecked());
 
         nstli.setSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters(ctv_ignore_unusable_character_used_directory_file_name.isChecked());
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
@@ -499,6 +499,10 @@ class SyncTaskItem implements Serializable, Cloneable {
     public void setSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile(boolean enabled) {syncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile=enabled;}
     public boolean isSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile() {return syncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile;}
 
+    private boolean SyncOptionIgnoreDstDifference = false;
+    public void setSyncOptionIgnoreDstDifference(boolean enabled) {SyncOptionIgnoreDstDifference=enabled;}
+    public boolean isSyncOptionIgnoreDstDifference() {return SyncOptionIgnoreDstDifference;}
+
     private boolean syncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters = false;
     public void setSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters(boolean enabled) {syncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters=enabled;}
     public boolean isSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters() {return syncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters;}
@@ -650,6 +654,8 @@ class SyncTaskItem implements Serializable, Cloneable {
                         (syncOptionUseExtendedDirectoryFilter1==sti.isSyncOptionUseExtendedDirectoryFilter1()) &&
 
                         (syncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile==sti.isSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile()) &&
+
+                        (SyncOptionIgnoreDstDifference==sti.isSyncOptionIgnoreDstDifference()) &&
 
                         (syncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters==sti.isSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters()) &&
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -6004,6 +6004,8 @@ public class SyncTaskUtil {
 
             if (!parm[79].equals("") && !parm[79].equals("end")) stli.setSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile((parm[79].equals("1") ? true : false));
 
+            if (!parm[91].equals("") && !parm[91].equals("end")) stli.setSyncOptionIgnoreDstDifference((parm[91].equals("1") ? true : false));
+
             if (!parm[80].equals("") && !parm[80].equals("end")) stli.setSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters((parm[80].equals("1") ? true : false));
 
             if (stli.getMasterSmbProtocol().equals(SyncTaskItem.SYNC_FOLDER_SMB_PROTOCOL_SYSTEM))
@@ -6205,6 +6207,8 @@ public class SyncTaskUtil {
             if (!parm[78].equals("") && !parm[78].equals("end")) stli.setTargetZipUseUsb((parm[78].equals("1") ? true : false));
 
             if (!parm[79].equals("") && !parm[79].equals("end")) stli.setSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile((parm[79].equals("1") ? true : false));
+
+            if (!parm[91].equals("") && !parm[91].equals("end")) stli.setSyncOptionIgnoreDstDifference((parm[91].equals("1") ? true : false));
 
             if (!parm[80].equals("") && !parm[80].equals("end")) stli.setSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters((parm[80].equals("1") ? true : false));
 
@@ -6480,6 +6484,8 @@ public class SyncTaskUtil {
             if (!parm[78].equals("") && !parm[78].equals("end")) stli.setTargetZipUseUsb((parm[78].equals("1") ? true : false));
 
             if (!parm[79].equals("") && !parm[79].equals("end")) stli.setSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile((parm[79].equals("1") ? true : false));
+
+            if (!parm[91].equals("") && !parm[91].equals("end")) stli.setSyncOptionIgnoreDstDifference((parm[91].equals("1") ? true : false));
 
             if (!parm[80].equals("") && !parm[80].equals("end")) stli.setSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters((parm[80].equals("1") ? true : false));
 
@@ -7003,6 +7009,7 @@ public class SyncTaskUtil {
 
                             (item.getMasterFolderError()) + "\t" +                                       //89
                             (item.getTargetFolderError()) + "\t" +                                       //90
+                            (item.isSyncOptionIgnoreDstDifference() ? "1" : "0") + "\t" +                //91
 
                     "end"
                     ;

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -470,6 +470,7 @@ public class SyncThread extends Thread {
                 ", LastModSmbsync2=" + sti.isSyncDetectLastModifiedBySmbsync() ,
                 ", UseLastMod=" + sti.isSyncOptionDifferentFileByTime() ,
                 ", NeverOverwriteTargetFileIfItIsNewerThanTheMasterFile=" + sti.isSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile(),
+				", IgnoreDstDifference=" + sti.isSyncOptionIgnoreDstDifference(),
                 ", UseFileSize=" + sti.isSyncOptionDifferentFileBySize() ,
                 ", UseFileSizeGreaterThanTagetFile=" + sti.isSyncDifferentFileSizeGreaterThanTagetFile() ,
                 ", DoNotResetFileLastMod=" + sti.isSyncDoNotResetFileLastModified() ,
@@ -490,8 +491,7 @@ public class SyncThread extends Thread {
                 ", SyncOnlyCharging=" + sti.isSyncOptionSyncWhenCharging() ,
                 ", DeleteFirst=" + sti.isSyncOptionDeleteFirstWhenMirror() ,
 
-                ", NeverOverwriteTargetFileIfItIsNewerThanTheMasterFile="+sti.isSyncOptionNeverOverwriteTargetFileIfItIsNewerThanTheMasterFile(),
-                ", IgnoreUnusableCharacterUsedDirectoryFileName="+sti.isSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters(),
+                ", IgnoreUnusableCharacterUsedDirectoryFileName=" + sti.isSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters(),
                 ", DoNotUseRenameWhenSmbFileWrite=" + sti.isSyncOptionDoNotUseRenameWhenSmbFileWrite() ,
                 "");
         mStwa.util.addDebugMsg(1, "I", "   SMB1 Option, LM Compatiibility=" + mGp.settingsSmbLmCompatibility +
@@ -526,6 +526,7 @@ public class SyncThread extends Thread {
 
         mStwa.syncTaskRetryCount = mStwa.syncTaskRetryCountOriginal = Integer.parseInt(sti.getSyncOptionRetryCount()) + 1;
         mStwa.syncDifferentFileAllowableTime = sti.getSyncOptionDifferentFileAllowableTime() * 1000;
+		if (sti.isSyncOptionIgnoreDstDifference()) mStwa.syncDifferentFileAllowableTime += 3600000;  // ignore DST difference: further increment the user set allowable time by 1h (3600 000 msec)
 
         mStwa.totalTransferByte = mStwa.totalTransferTime = 0;
         mStwa.totalCopyCount = mStwa.totalDeleteCount = mStwa.totalIgnoreCount = mStwa.totalRetryCount = 0;

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
@@ -468,6 +468,22 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/edit_sync_task_option_sync_diff_ignore_dst_difference_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+                <CheckedTextView
+                    android:id="@+id/edit_sync_task_option_ctv_sync_diff_ignore_dst_difference"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                    android:gravity="center_vertical"
+                    android:text="@string/msgs_profile_sync_task_sync_option_diff_file_ignore_dst_difference"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                <include layout="@layout/divider_line1" />
+            </LinearLayout>
+
+            <LinearLayout
                 android:id="@+id/edit_sync_task_option_ignore_unusable_character_used_directory_file_name_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
@@ -409,6 +409,7 @@
         <string name="msgs_profile_sync_task_sync_option_last_modified_smbsync">強制的にSMBSync2で最終更新日時を取得</string>
         <string name="msgs_profile_sync_task_sync_option_master_root_dir_file">マスターで指定されたディレクトリの直下に存在するファイルを処理する</string>
         <string name="msgs_profile_sync_task_sync_option_never_overwrite_target_file_if_it_is_newer_than_the_master_file">ターゲットファイルがマスターファイルより新しい時はターゲットファイルを上書きしない</string>
+        <string name="msgs_profile_sync_task_sync_option_diff_file_ignore_dst_difference">夏時間を無視する</string>
         <string name="msgs_profile_sync_task_sync_option_not_set_file_last_modified">ターゲットファイルの最終更新時刻をマスターと同じにしない</string>
         <string name="msgs_profile_sync_task_sync_option_perform_overriden_copy_move">ファイルを上書きする</string>
         <string name="msgs_profile_sync_task_sync_option_retry_if_error_occured">ネットワークエラーが発生した場合にリトライする</string>

--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -411,6 +411,7 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_profile_sync_task_sync_option_last_modified_smbsync">Forced to get the last update date and time in SMBSync2</string>
         <string name="msgs_profile_sync_task_sync_option_master_root_dir_file">Sync files located in root of source directory.</string>
         <string name="msgs_profile_sync_task_sync_option_never_overwrite_target_file_if_it_is_newer_than_the_master_file">Do not overwrite destination file if newer than source file</string>
+        <string name="msgs_profile_sync_task_sync_option_diff_file_ignore_dst_difference">Ignore 1 hour Day Light Saving Time difference between files</string>
         <string name="msgs_profile_sync_task_sync_option_not_set_file_last_modified">Do not set update time of destination file to match source file</string>
         <string name="msgs_profile_sync_task_sync_option_perform_overriden_copy_move">Overwrite destination file(s)</string>
         <string name="msgs_profile_sync_task_sync_option_retry_if_error_occured">Retry on network error</string>


### PR DESCRIPTION
Proper implementation of option to ignore DST difference when synchronising files
Option is implemented as a new check-mark. It is automatically greyed out if "Use time of last update to determine file difference" is unchecked