### PR TITLE
Fix for "older" files and discussion 2

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/FileLastModifiedTime.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/FileLastModifiedTime.java
@@ -119,10 +119,10 @@ public class FileLastModifiedTime {
                 long diff_rmt = Math.abs(curr_last_modified_list.get(idx).getRemoteFileLastModified() - r_lm);
                 if (diff_lcl > timeDifferenceLimit || diff_rmt > timeDifferenceLimit) {
                     if (ignore_dst_time) {
-                        if (diff_lcl<dstOffset || diff_lcl>timeDifferenceForDst) result = true;
-                        if (diff_rmt<dstOffset || diff_rmt>timeDifferenceForDst) result = true;
+                        if (diff_lcl<dstOffset || diff_lcl>timeDifferenceForDst) result = true; // 1
+                        if (diff_rmt<dstOffset || diff_rmt>timeDifferenceForDst) result = true; // 2
                     } else {
-                        result=true;
+                        result=true; // 3: same as 1 and 2 comments !!
                     }
                 }
                 curr_last_modified_list.get(idx).setReferenced(true);


### PR DESCRIPTION
the 3 commented lines end with same result
See my commit to SyncThread.java file: your code also here won't account for diff_lcl == 3598 seconds (< 3600) yet only DST Offset +/- 2 sec
Also issues if ignore_dst_time == true and dstOffset == 0, so better go with either on or off, default is off so files are always same time unless user wants to tolerate the DST

PS: I am not sure in your code of the use of isCurrentListWasDifferent(), sorry as I didn't have time to  more look through it
best regards