### PR TITLE
Fix error in dst time diff

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -2499,7 +2499,7 @@ public class SyncThread extends Thread {
                             diff=true;
                         }
                     } else {
-                        diff = false;
+                        diff = true;
                     }
                 } else {
                     diff = false;


### PR DESCRIPTION
if (time_diff > stwa.syncDifferentFileAllowableTime) && !isSyncOptionIgnoreDstDifference() --> diff = true