### PR TITLE
more exceptions and discussion

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3148,6 +3148,8 @@ public class SyncTaskEditor extends DialogFragment {
         for(int i=10;i<121;i+=10) adapter.add(String.valueOf(i));
         if (cv>=10 && cv<=120) {
             spinner.setSelection((cv/10)-1);
+        } else {
+            spinner.setSelection(5); // position 5, default 60 mn if invalid range provided from settings file
         }
 
         adapter.notifyDataSetChanged();


### PR DESCRIPTION
A 300 setting could be passed through settings files for example
look in next commit for a more general approach. This only fixes the spinner default, but not the corruption of the sync if we don't edit the broken task setting