### PR TITLE
Exceptions handling: a proper global approach

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -6369,7 +6369,11 @@ public class SyncTaskUtil {
             stli.setSyncOptionSyncSubDirectory(parm[31].equals("1") ? true : false);
             stli.setSyncOptionUseSmallIoBuffer(parm[32].equals("1") ? true : false);
             stli.setSyncTestMode(parm[33].equals("1") ? true : false);
-            try {stli.setSyncOptionDifferentFileAllowableTime(Integer.parseInt(parm[34]));} catch(Exception e) {}
+            try {
+                stli.setSyncOptionDifferentFileAllowableTime(Integer.parseInt(parm[34]));
+            } catch(Exception e) {
+                setSyncOptionDifferentFileAllowableTime(3);
+            }
             stli.setSyncOptionDifferentFileByTime(parm[35].equals("1") ? true : false);
 
 //            stli.setSyncUseFileCopyByTempNamex(parm[36].equals("1") ? true : false);


### PR DESCRIPTION
The approach in this commit is only partial
Same for most the addSyncTaskListVer8() parsed options + all the catch(Exception e){} empty entries

**exp+proof of concept:** we manually edit settings file and change entries for dst_offset and time_diff_allowable_time to 600. Open SMBSync2, import the hacked task list. Do not enter settings, exit SMBSync2. Open the auto-saved task list created on exit: it will contain the 600 value for both the hacked fields.

If we start the sync: setSyncOptionDifferentFileAllowableTime(600) is triggered and getSyncOptionDifferentFileAllowableTime() will always return 600 in the active session unless we go to task settings. The parser Exception won't trigger since 600 is an integer. The sync task will effectively apply 600 seconds time offset. Same for the dst offset. Only if we edit the task in advanced settings, problem is fixed

Whenever we read a settings file, we must account for corruption, user modifications and exceptions. I think all the entries in addSyncTaskListVer8() should be checked at read, and proper default values set if invalid entries detected. This is a rule when a program accepts values from a user input or external file.

**fix approach 1 (faster to code, but complicated to maintain):** 

exp (code not exact):
```
private static void addSyncTaskListVer8(..) {
                ...
                int set = Integer.parseInt(parm[34];
                // add code to handle exception if it is an invalid string like "zzz"
                if (set != 1 or or 3 or 10) // valid range or values
                    set = 3; // default value
                stli.setSyncOptionDifferentFileAllowableTime(set);
                ...
}
```

**A better approach 2 example:** (simpler for management and code update)

```
(SyncTaskUtil.java)
// we only check if it is valid type, integer vs string for example
private static void addSyncTaskListVer8(..) {
                ...
                int set;
                try {
                       set = Integer.valueOf(parm[34]);
                     } catch(Exception e) {
                       set = syncOptionDeterminChangedFileByTimeValue_default;
                     }
                stli.setSyncOptionDifferentFileAllowableTime(set);
                ...
}

(SyncTaskItem.java)
// here we define the defaults
private int syncOptionDeterminChangedFileByTimeValue_default = 3;
public void setSyncOptionDifferentFileAllowableTime(int p) {
   if (p != // code to check valid range / values) {
       p = syncOptionDeterminChangedFileByTimeValue_default;
       // code to warn in messages that an invalid entry was read and resetted to default
   }
   syncOptionDeterminChangedFileByTimeValue = p;
}

```

**Approach 3,:** Even more simpler management of the code

Just read all user settings in addSyncTaskListVer8() and pass them as strings to
ValidateInput_SyncOptionDifferentFileAllowableTime(string value) functions

```
(SyncTaskUtil.java)
// read all user settings as strings
private static void addSyncTaskListVer8(..) {
                ...
                stli.ValidateInput_SyncOptionDifferentFileAllowableTime(parm[34]);
                ...
}

(SyncTaskItem.java)
// validate entries and set defaults

private int syncOptionDeterminChangedFileByTimeValue_default = 3;
public void ValidateInput_SyncOptionDifferentFileAllowableTime(string value) {
   int set;
   if (value != // code to check valid type, range and values) {
       set = syncOptionDeterminChangedFileByTimeValue_default;
       // code to warn in messages that an invalid entry was read and resetted to default
   } else set = Integer.valueOf(value);

   setSyncOptionDifferentFileAllowableTime(set);
}
```

This way all defaults and type/range/values are checked in same code area
shouldn't be complicated to code at all. Once done, maintenance is easier.

Hope you can fix it as you are used to the code. It would take me weeks to look through all your code to get the proper defaults :-)

Best regards