### PR TITLE
Bug fix in Wifi AP selection:

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3234,7 +3234,7 @@ public class SyncTaskEditor extends DialogFragment {
         } else if (type.equals("ADD")) {
             dlg_title.setText(mContext.getString(R.string.msgs_add_sync_profile));
             dlg_title_sub.setVisibility(TextView.GONE);
-            n_sti.setSyncOptionWifiStatusOption("0");
+            n_sti.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF);
         }
         final CheckedTextView ctv_auto = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_ctv_auto);
         CommonUtilities.setCheckedTextView(ctv_auto);
@@ -3783,7 +3783,7 @@ public class SyncTaskEditor extends DialogFragment {
                                         @Override
                                         public void positiveResponse(Context context, Object[] objects) {
                                             n_sti.setSyncOptionWifiStatusOption(option);
-                                            spinnerSyncWifiStatus.setSelection(1);
+                                            spinnerSyncWifiStatus.setSelection(Integer.valueOf(option));
                                             confirmUseAppSpecificDir(n_sti, n_sti.getMasterDirectoryName(), null);
                                         }
 
@@ -3942,7 +3942,7 @@ public class SyncTaskEditor extends DialogFragment {
                                         @Override
                                         public void positiveResponse(Context context, Object[] objects) {
                                             n_sti.setSyncOptionWifiStatusOption(option);
-                                            spinnerSyncWifiStatus.setSelection(1);
+                                            spinnerSyncWifiStatus.setSelection(Integer.valueOf(option));
                                             confirmUseAppSpecificDir(n_sti, n_sti.getTargetDirectoryName(), null);
                                         }
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -5072,7 +5072,7 @@ public class SyncTaskUtil {
         stli.setTargetFolderType(SyncTaskItem.SYNC_FOLDER_TYPE_INTERNAL);
         stli.setTargetDirectoryName("Pictures");
 
-        stli.setSyncOptionWifiStatusOption("1");
+        stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP);
         stli.setSyncOptionUseExtendedDirectoryFilter1(true);
         stli.setSyncTaskPosition(0);
         pfl.add(stli);
@@ -5090,7 +5090,7 @@ public class SyncTaskUtil {
         stli.setSyncTestMode(false);
         stli.setTargetDirectoryName("Android/DCIM");
 
-        stli.setSyncOptionWifiStatusOption("1");
+        stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP);
         stli.setSyncOptionUseExtendedDirectoryFilter1(true);
         stli.setSyncTaskPosition(1);
         pfl.add(stli);
@@ -5103,7 +5103,7 @@ public class SyncTaskUtil {
         stli.setTargetFolderType(SyncTaskItem.SYNC_FOLDER_TYPE_SDCARD);
         stli.setTargetDirectoryName("Pictures");
         stli.setSyncTestMode(false);
-        stli.setSyncOptionWifiStatusOption("0");
+        stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF);
 
         stli.setSyncOptionUseExtendedDirectoryFilter1(true);
         stli.setSyncTaskPosition(2);


### PR DESCRIPTION
on Android SDK 27, if location service is disabled, when we create a task with smb share, a prompt asks to set the WIFI AP to "Private address". If we answer ok, the Wifi AP was regardless set to "Any AP"