### PR TITLE
Default settings fixes

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3082,10 +3082,10 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.add(mContext.getString(R.string.msgs_profile_twoway_sync_conflict_copy_rurle_skip_sync_file));
 
         int sel = 0;
-        if (cv.equals("0")) sel = 0;
-        else if (cv.equals("1")) sel = 1;
-        else if (cv.equals("2")) sel = 2;
-        else if (cv.equals("3")) sel = 3;
+        if (cv.equals(SyncTaskItem.SYNC_TASK_TWO_WAY_OPTION_ASK_USER)) sel = 0;
+        else if (cv.equals(SyncTaskItem.SYNC_TASK_TWO_WAY_OPTION_COPY_NEWER)) sel = 1;
+        else if (cv.equals(SyncTaskItem.SYNC_TASK_TWO_WAY_OPTION_COPY_OLDER)) sel = 2;
+        else if (cv.equals(SyncTaskItem.SYNC_TASK_TWO_WAY_OPTION_SKIP_SYNC_FILE)) sel = 3;
 
         spinner.setSelection(sel);
 
@@ -3106,11 +3106,11 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_wifi_option_wifi_connect_specific_address));
 
         int sel = 0;
-        if (cv.equals("0")) sel = 0;
-        else if (cv.equals("1")) sel = 1;
-        else if (cv.equals("2")) sel = 2;
-        else if (cv.equals("3")) sel = 3;
-        else if (cv.equals("4")) sel = 4;
+        if (cv.equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF)) sel = 0;
+        else if (cv.equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP)) sel = 1;
+        else if (cv.equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_AP)) sel = 2;
+        else if (cv.equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_PRIVATE_ADDR)) sel = 3;
+        else if (cv.equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_ADDR)) sel = 4;
 
         spinner.setSelection(sel);
 
@@ -3124,14 +3124,14 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.setDropDownViewResource(android.R.layout.select_dialog_singlechoice);
         spinner.setPrompt(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_prompt));
         spinner.setAdapter(adapter);
+        adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_0));
         adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_1));
-        adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_3));
-        adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_10));
+        adapter.add(mContext.getString(R.string.msgs_main_sync_profile_dlg_diff_time_value_option_2));
 
         int sel = 0;
-        if (cv == 1) sel = 0;
-        else if (cv == 3) sel = 1;
-        else if (cv == 10) sel = 2;
+        if (cv == SyncTaskItem.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0) sel = 0;
+        else if (cv == SyncTaskItem.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1) sel = 1;
+        else if (cv == SyncTaskItem.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2) sel = 2;
 
         spinner.setSelection(sel);
 
@@ -3145,7 +3145,7 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.setDropDownViewResource(android.R.layout.select_dialog_singlechoice);
         spinner.setPrompt(mContext.getString(R.string.msgs_profile_sync_task_sync_option_offset_of_dst_time_value_title));
         spinner.setAdapter(adapter);
-        int sel=5;
+        int sel=SyncTaskItem.SYNC_OPTION_OFFSET_OF_DST_LIST_DEFAULT_ITEM_INDEX;
         for(int i=0;i<SyncTaskItem.SYNC_OPTION_OFFSET_OF_DST_LIST.length;i++) {
             int item=SyncTaskItem.SYNC_OPTION_OFFSET_OF_DST_LIST[i];
             adapter.add(String.valueOf(item));
@@ -3234,7 +3234,7 @@ public class SyncTaskEditor extends DialogFragment {
         } else if (type.equals("ADD")) {
             dlg_title.setText(mContext.getString(R.string.msgs_add_sync_profile));
             dlg_title_sub.setVisibility(TextView.GONE);
-            n_sti.setSyncOptionWifiStatusOption("0");
+            n_sti.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF);
         }
         final CheckedTextView ctv_auto = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_ctv_auto);
         CommonUtilities.setCheckedTextView(ctv_auto);
@@ -3783,7 +3783,7 @@ public class SyncTaskEditor extends DialogFragment {
                                         @Override
                                         public void positiveResponse(Context context, Object[] objects) {
                                             n_sti.setSyncOptionWifiStatusOption(option);
-                                            spinnerSyncWifiStatus.setSelection(1);
+                                            spinnerSyncWifiStatus.setSelection(Integer.valueOf(option));
                                             confirmUseAppSpecificDir(n_sti, n_sti.getMasterDirectoryName(), null);
                                         }
 
@@ -3942,7 +3942,7 @@ public class SyncTaskEditor extends DialogFragment {
                                         @Override
                                         public void positiveResponse(Context context, Object[] objects) {
                                             n_sti.setSyncOptionWifiStatusOption(option);
-                                            spinnerSyncWifiStatus.setSelection(1);
+                                            spinnerSyncWifiStatus.setSelection(Integer.valueOf(option));
                                             confirmUseAppSpecificDir(n_sti, n_sti.getTargetDirectoryName(), null);
                                         }
 
@@ -4275,12 +4275,12 @@ public class SyncTaskEditor extends DialogFragment {
         adapter.add(mContext.getString(R.string.msgs_sync_folder_archive_suffix_seq_digit_5));
         adapter.add(mContext.getString(R.string.msgs_sync_folder_archive_suffix_seq_digit_6));
 
-        int sel=0;
-        if (cv.equals("0")) sel=0;
-        else if (cv.equals("3")) sel=1;
-        else if (cv.equals("4")) sel=2;
-        else if (cv.equals("5")) sel=3;
-        else if (cv.equals("6")) sel=4;
+        int sel=SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT;
+        if (cv.equals(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_NOT_USED)) sel=0;
+        else if (cv.equals(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_3_DIGIT)) sel=1;
+        else if (cv.equals(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_4_DIGIT)) sel=2;
+        else if (cv.equals(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_5_DIGIT)) sel=3;
+        else if (cv.equals(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_6_DIGIT)) sel=4;
         spinner.setSelection(sel);
 
     }

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
@@ -51,11 +51,12 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static String SYNC_TASK_TYPE_MIRROR = "M";
     public final static String SYNC_TASK_TYPE_COPY = "C";
     public final static String SYNC_TASK_TYPE_MOVE = "X";
-    public final static String SYNC_TASK_TYPE_SYNC = "S";
     public final static String SYNC_TASK_TYPE_ARCHIVE = "A";
+    public final static String SYNC_TASK_TYPE_SYNC = "S";
     public final static String SYNC_TASK_TYPE_DEFAULT = SYNC_TASK_TYPE_COPY;
-    public final static String[] SYNC_TASK_TYPE_LIST=new String[]{SYNC_TASK_TYPE_ARCHIVE, SYNC_TASK_TYPE_COPY, SYNC_TASK_TYPE_MIRROR, SYNC_TASK_TYPE_MOVE, SYNC_TASK_TYPE_SYNC};
-    private String syncTaskType = SYNC_TASK_TYPE_MIRROR;
+    public final static String SYNC_TASK_TYPE_DEFAULT_DESCRIPTION = "COPY";
+    public final static String[] SYNC_TASK_TYPE_LIST=new String[]{SYNC_TASK_TYPE_MIRROR, SYNC_TASK_TYPE_COPY, SYNC_TASK_TYPE_MOVE, SYNC_TASK_TYPE_ARCHIVE, SYNC_TASK_TYPE_SYNC};
+    private String syncTaskType = SYNC_TASK_TYPE_DEFAULT;
 
     public final static String SYNC_TASK_TWO_WAY_OPTION_ASK_USER = "0";
     public final static String SYNC_TASK_TWO_WAY_OPTION_COPY_NEWER = "1";
@@ -65,7 +66,7 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static String[] SYNC_TASK_TWO_WAY_OPTION_LIST=new String[]{
             SYNC_TASK_TWO_WAY_OPTION_ASK_USER, SYNC_TASK_TWO_WAY_OPTION_COPY_NEWER, SYNC_TASK_TWO_WAY_OPTION_COPY_OLDER, SYNC_TASK_TWO_WAY_OPTION_SKIP_SYNC_FILE};
     public final static String SYNC_TASK_TWO_WAY_CONFLICT_FILE_SUFFIX=".smbsync2_conflict";
-    private String syncTwoWayConflictOption =SYNC_TASK_TWO_WAY_OPTION_COPY_NEWER;
+    private String syncTwoWayConflictOption =SYNC_TASK_TWO_WAY_OPTION_DEFAULT;
     private boolean syncTwoWayConflictKeepConflictFile = false;
 
     public final static String SYNC_FOLDER_TYPE_INTERNAL = "INT";
@@ -75,14 +76,14 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static String SYNC_FOLDER_TYPE_ZIP = "ZIP";
     public final static String SYNC_FOLDER_TYPE_DEFAULT = SYNC_FOLDER_TYPE_INTERNAL;
     public final static String[] SYNC_FOLDER_TYPE_LIST=new String[]{SYNC_FOLDER_TYPE_INTERNAL, SYNC_FOLDER_TYPE_SDCARD, SYNC_FOLDER_TYPE_USB, SYNC_FOLDER_TYPE_ZIP, SYNC_FOLDER_TYPE_SMB};
-    private String syncTaskMasterFolderType = SYNC_FOLDER_TYPE_INTERNAL;
+    private String syncTaskMasterFolderType = SYNC_FOLDER_TYPE_DEFAULT;
 
     private String syncTaskMasterFolderDirName = "";
     private String syncTaskMasterLocalMountPoint = "";
     private String syncTaskMasterFolderSmbShareName = "";
     private String syncTaskMasterFolderSmbIpAddress = "";
     private String syncTaskMasterFolderSmbHostName = "";
-    private String syncTaskMasterFolderSmbPortNumber = "";
+    private String syncTaskMasterFolderSmbPortNumber = SYNC_FOLDER_SMB_PORT_DEFAULT;
     private String syncTaskMasterFolderSmbUserName = "";
     private String syncTaskMasterFolderSmbPassword = "";
     private String syncTaskMasterFolderSmbDomain = "";
@@ -97,10 +98,11 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static String SYNC_FOLDER_SMB_PROTOCOL_SMB211 = String.valueOf(JcifsAuth.JCIFS_FILE_SMB211);
     public final static String SYNC_FOLDER_SMB_PROTOCOL_SMB212 = String.valueOf(JcifsAuth.JCIFS_FILE_SMB212);
     public final static String SYNC_FOLDER_SMB_PROTOCOL_DEFAULT = SYNC_FOLDER_SMB_PROTOCOL_SMB212;
+    public final static String SYNC_FOLDER_SMB_PROTOCOL_DEFAULT_DESCRIPTION = "SMB212";
     public final static String[] SYNC_FOLDER_SMB_PROTOCOL_LIST=new String[]{
             SYNC_FOLDER_SMB_PROTOCOL_SMB1, SYNC_FOLDER_SMB_PROTOCOL_SMB201, SYNC_FOLDER_SMB_PROTOCOL_SMB211, SYNC_FOLDER_SMB_PROTOCOL_SMB212};
 
-    private String syncTaskMasterFolderSmbProtocol = SYNC_FOLDER_SMB_PROTOCOL_SMB212;
+    private String syncTaskMasterFolderSmbProtocol = SYNC_FOLDER_SMB_PROTOCOL_DEFAULT;
     private boolean syncTaskMasterFolderSmbIpcSigningEnforced = true;
 
     private boolean syncTaskMasterFolderSmbUseSmb2Negotiation = false;
@@ -143,9 +145,9 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static String ZIP_OPTION_ENCRYPT_AES256 = "AES256";
     public final static String ZIP_OPTION_ENCRYPT_DEFAULT = ZIP_OPTION_ENCRYPT_STANDARD ;
     public final static String[] ZIP_OPTION_ENCRYPT_LIST=new String[]{ZIP_OPTION_ENCRYPT_NONE, ZIP_OPTION_ENCRYPT_STANDARD, ZIP_OPTION_ENCRYPT_AES128, ZIP_OPTION_ENCRYPT_AES256};
-    private String syncTaskTargetZipCompOptionCompLevel = ZIP_OPTION_COMP_LEVEL_NORMAL;
-    private String syncTaskTargetZipCompOptionCompMethod = ZIP_OPTION_COMP_METHOD_DEFLATE;
-    private String syncTaskTargetZipCompOptionEncrypt = ZIP_OPTION_ENCRYPT_NONE;
+    private String syncTaskTargetZipCompOptionCompLevel = ZIP_OPTION_COMP_LEVEL_DEFAULT;
+    private String syncTaskTargetZipCompOptionCompMethod = ZIP_OPTION_COMP_METHOD_DEFAULT;
+    private String syncTaskTargetZipCompOptionEncrypt = ZIP_OPTION_ENCRYPT_DEFAULT;
     private String syncTaskTargetZipCompOptionPassword = "";
     private String syncTaskTargetZipCompOptionEncoding = "UTF-8";
     //	private boolean syncTaskTargetZipUseInternalUsbFolder=false;
@@ -167,9 +169,9 @@ class SyncTaskItem implements Serializable, Cloneable {
     private boolean syncOptionNotUsedLastModifiedForRemote = false;
 
     public final static String NETWORK_ERROR_RETRY_COUNT="3";
-    public final static String NETWORK_ERROR_RETRY_COUNT_DEFSULT=NETWORK_ERROR_RETRY_COUNT;
-    public final static String[] NETWORK_ERROR_RETRY_COUNT_LIST=new String[]{NETWORK_ERROR_RETRY_COUNT_DEFSULT};
-    private String syncOptionRetryCount = NETWORK_ERROR_RETRY_COUNT_DEFSULT;
+    public final static String NETWORK_ERROR_RETRY_COUNT_DEFAULT=NETWORK_ERROR_RETRY_COUNT;
+    public final static String[] NETWORK_ERROR_RETRY_COUNT_LIST=new String[]{NETWORK_ERROR_RETRY_COUNT_DEFAULT};
+    private String syncOptionRetryCount = NETWORK_ERROR_RETRY_COUNT_DEFAULT;
     private boolean syncOptionSyncEmptyDir = true;
     private boolean syncTaskTargetUseTakenDateTimeForDirectoryNameKeyword = false;
     private boolean syncOptionSyncHiddenFile = true;
@@ -180,12 +182,12 @@ class SyncTaskItem implements Serializable, Cloneable {
 
     private boolean syncOptionDeterminChangedFileBySize = true;
     private boolean syncOptionDeterminChangedFileByTime = true;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1=1;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_3=3;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_10=10;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT=SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_3;
-    public final static int[] SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_LIST =new int[]{SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_3, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_10};
-    private int syncOptionDeterminChangedFileByTimeValue = SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_3;//Seconds
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0=1;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1=3;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2=10;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT=SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0;
+    public final static int[] SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_LIST =new int[]{SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2};
+    private int syncOptionDeterminChangedFileByTimeValue = SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT;//Seconds
 
     private boolean syncOptionDoNotUseRenameWhenSmbFileWrite = false;
 
@@ -199,23 +201,25 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static String SYNC_WIFI_STATUS_WIFI_CONNECT_PRIVATE_ADDR = "3";
     public final static String SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_ADDR = "4";
     public final static String SYNC_WIFI_STATUS_WIFI_DEFAULT = SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP;
+    public final static String SYNC_WIFI_STATUS_WIFI_DEFAULT_DESCRIPTION = "Conn any AP";
     public final static String[] SYNC_WIFI_STATUS_WIFI_LIST = new String[]{SYNC_WIFI_STATUS_WIFI_OFF , SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP,
-            SYNC_WIFI_STATUS_WIFI_CONNECT_PRIVATE_ADDR, SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_ADDR, SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_AP};
-    private String syncOptionWifiStatus = SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP;
+            SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_AP, SYNC_WIFI_STATUS_WIFI_CONNECT_PRIVATE_ADDR, SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_ADDR};
+    private String syncOptionWifiStatus = SYNC_WIFI_STATUS_WIFI_DEFAULT;
     private boolean syncTaskSkipIfConnectAnotherWifiSsid = false;
 
     private boolean syncOptionSyncOnlyCharging = false;
 
     private boolean syncOptionSyncAllowGlobalIpAddress=false;
 
-    private String syncLastSyncTime = "";
-    private int syncLastSyncResult = 0;
     static public final int SYNC_STATUS_SUCCESS = SyncHistoryItem.SYNC_STATUS_SUCCESS;
     static public final int SYNC_STATUS_CANCEL = SyncHistoryItem.SYNC_STATUS_CANCEL;
     static public final int SYNC_STATUS_ERROR = SyncHistoryItem.SYNC_STATUS_ERROR;
     static public final int SYNC_STATUS_WARNING = SyncHistoryItem.SYNC_STATUS_WARNING;
     static public final int SYNC_STATUS_DEFAULT = SYNC_STATUS_SUCCESS;
+    public final static String SYNC_STATUS_DEFAULT_DESCRIPTION = "Success";
     public final static int[] SYNC_STATUS_LIST = new int[]{SYNC_STATUS_SUCCESS, SYNC_STATUS_CANCEL, SYNC_STATUS_ERROR, SYNC_STATUS_WARNING};
+    private String syncLastSyncTime = "";
+    private int syncLastSyncResult = SYNC_STATUS_DEFAULT;
 
     //Not save variables
     private boolean syncTaskIsRunning = false;
@@ -366,10 +370,11 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static int PICTURE_ARCHIVE_RETAIN_FOR_A_180_DAYS = 5;
     public final static int PICTURE_ARCHIVE_RETAIN_FOR_A_1_YEARS = 6;
     public final static int PICTURE_ARCHIVE_RETAIN_FOR_A_DEFAULT = PICTURE_ARCHIVE_RETAIN_FOR_A_180_DAYS;
+    public final static String PICTURE_ARCHIVE_RETAIN_FOR_A_DEFAULT_DESCRIPTION = "180 Days";
     public final static int[] PICTURE_ARCHIVE_RETAIN_FOR_A_LIST = new int[]{PICTURE_ARCHIVE_RETAIN_FOR_A_0_DAYS,
             PICTURE_ARCHIVE_RETAIN_FOR_A_7_DAYS, PICTURE_ARCHIVE_RETAIN_FOR_A_30_DAYS, PICTURE_ARCHIVE_RETAIN_FOR_A_60_DAYS,
             PICTURE_ARCHIVE_RETAIN_FOR_A_90_DAYS, PICTURE_ARCHIVE_RETAIN_FOR_A_180_DAYS, PICTURE_ARCHIVE_RETAIN_FOR_A_1_YEARS};
-    private int syncTaskArchiveRetentionPeriod = PICTURE_ARCHIVE_RETAIN_FOR_A_180_DAYS;
+    private int syncTaskArchiveRetentionPeriod = PICTURE_ARCHIVE_RETAIN_FOR_A_DEFAULT;
 
     private boolean syncTaskArchiveCreateDirectory = false;
 
@@ -383,7 +388,7 @@ class SyncTaskItem implements Serializable, Cloneable {
     public final static int PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT = PICTURE_ARCHIVE_SUFFIX_DIGIT_4_DIGIT ;
     public final static int[] PICTURE_ARCHIVE_SUFFIX_DIGIT_LIST = new int[]{PICTURE_ARCHIVE_SUFFIX_DIGIT_NOT_USED, PICTURE_ARCHIVE_SUFFIX_DIGIT_3_DIGIT,
             PICTURE_ARCHIVE_SUFFIX_DIGIT_4_DIGIT, PICTURE_ARCHIVE_SUFFIX_DIGIT_5_DIGIT, PICTURE_ARCHIVE_SUFFIX_DIGIT_6_DIGIT};
-    private String syncTaskArchiveSuffixDigit = String.valueOf(PICTURE_ARCHIVE_SUFFIX_DIGIT_4_DIGIT);
+    private String syncTaskArchiveSuffixDigit = String.valueOf(PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT);
 
     public String getArchiveSuffixOption() {return syncTaskArchiveSuffixDigit;}
     public void setArchiveSuffixOption(String digit) {syncTaskArchiveSuffixDigit =digit;}
@@ -556,18 +561,19 @@ class SyncTaskItem implements Serializable, Cloneable {
     public void setSyncOptionIgnoreDstDifference(boolean enabled) {syncOptionIgnoreDstDifference =enabled;}
     public boolean isSyncOptionIgnoreDstDifference() {return syncOptionIgnoreDstDifference;}
 
-    public static final int SYNC_OPTION_OFFSET_OF_DST_10_MIN=10;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_20_MIN=20;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_30_MIN=30;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_40_MIN=40;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_50_MIN=50;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_60_MIN=60;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_70_MIN=70;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_80_MIN=80;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_90_MIN=90;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_100_MIN=100;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_110_MIN=110;
-    public static final int SYNC_OPTION_OFFSET_OF_DST_120_MIN=120;
+    public static final int SYNC_OPTION_OFFSET_OF_DST_10_MIN=10; // index 0
+    public static final int SYNC_OPTION_OFFSET_OF_DST_20_MIN=20; // index 1
+    public static final int SYNC_OPTION_OFFSET_OF_DST_30_MIN=30; // index 2
+    public static final int SYNC_OPTION_OFFSET_OF_DST_40_MIN=40; // index 3
+    public static final int SYNC_OPTION_OFFSET_OF_DST_50_MIN=50; // index 4
+    public static final int SYNC_OPTION_OFFSET_OF_DST_60_MIN=60; // index 5
+    public static final int SYNC_OPTION_OFFSET_OF_DST_70_MIN=70; // index 6
+    public static final int SYNC_OPTION_OFFSET_OF_DST_80_MIN=80; // index 7
+    public static final int SYNC_OPTION_OFFSET_OF_DST_90_MIN=90; // index 8
+    public static final int SYNC_OPTION_OFFSET_OF_DST_100_MIN=100; // index
+    public static final int SYNC_OPTION_OFFSET_OF_DST_110_MIN=110; // index 10
+    public static final int SYNC_OPTION_OFFSET_OF_DST_120_MIN=120; // index 11
+    public static final int SYNC_OPTION_OFFSET_OF_DST_LIST_DEFAULT_ITEM_INDEX=5; // default list index
     public static final int[] SYNC_OPTION_OFFSET_OF_DST_LIST=new int[]{SYNC_OPTION_OFFSET_OF_DST_10_MIN, SYNC_OPTION_OFFSET_OF_DST_20_MIN,
             SYNC_OPTION_OFFSET_OF_DST_30_MIN, SYNC_OPTION_OFFSET_OF_DST_40_MIN, SYNC_OPTION_OFFSET_OF_DST_50_MIN, SYNC_OPTION_OFFSET_OF_DST_60_MIN,
             SYNC_OPTION_OFFSET_OF_DST_70_MIN, SYNC_OPTION_OFFSET_OF_DST_80_MIN, SYNC_OPTION_OFFSET_OF_DST_90_MIN, SYNC_OPTION_OFFSET_OF_DST_100_MIN,

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -5072,7 +5072,7 @@ public class SyncTaskUtil {
         stli.setTargetFolderType(SyncTaskItem.SYNC_FOLDER_TYPE_INTERNAL);
         stli.setTargetDirectoryName("Pictures");
 
-        stli.setSyncOptionWifiStatusOption("1");
+        stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP);
         stli.setSyncOptionUseExtendedDirectoryFilter1(true);
         stli.setSyncTaskPosition(0);
         pfl.add(stli);
@@ -5090,7 +5090,7 @@ public class SyncTaskUtil {
         stli.setSyncTestMode(false);
         stli.setTargetDirectoryName("Android/DCIM");
 
-        stli.setSyncOptionWifiStatusOption("1");
+        stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_ANY_AP);
         stli.setSyncOptionUseExtendedDirectoryFilter1(true);
         stli.setSyncTaskPosition(1);
         pfl.add(stli);
@@ -5103,7 +5103,7 @@ public class SyncTaskUtil {
         stli.setTargetFolderType(SyncTaskItem.SYNC_FOLDER_TYPE_SDCARD);
         stli.setTargetDirectoryName("Pictures");
         stli.setSyncTestMode(false);
-        stli.setSyncOptionWifiStatusOption("0");
+        stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF);
 
         stli.setSyncOptionUseExtendedDirectoryFilter1(true);
         stli.setSyncTaskPosition(2);
@@ -6285,8 +6285,8 @@ public class SyncTaskUtil {
             if (isValidTaskItemValue(SyncTaskItem.SYNC_TASK_TYPE_LIST, parm[3])) {
                 stli.setSyncTaskType(parm[3]);
             } else {
-                stli.setSyncTaskType(SyncTaskItem.SYNC_TASK_TYPE_COPY);
-                putTaskListValueErrorMessage(util, "Sync task type", "COPY");
+                stli.setSyncTaskType(SyncTaskItem.SYNC_TASK_TYPE_DEFAULT);
+                putTaskListValueErrorMessage(util, "Sync task type", SyncTaskItem.SYNC_TASK_TYPE_DEFAULT_DESCRIPTION);
             }
 
             if (isValidTaskItemValue(SyncTaskItem.SYNC_FOLDER_TYPE_LIST, parm[4])) {
@@ -6325,7 +6325,7 @@ public class SyncTaskUtil {
             stli.setMasterDirectoryName(parm[8]);
             stli.setMasterSmbAddr(parm[9]);
             if (!parm[10].equals("")) {
-                int port_number=445;
+                int port_number=Integer.valueOf(SyncTaskItem.SYNC_FOLDER_SMB_PORT_DEFAULT);
                 try {
                     port_number=Integer.parseInt(parm[10]);
                     stli.setMasterSmbPort(parm[10]);
@@ -6372,7 +6372,7 @@ public class SyncTaskUtil {
             stli.setTargetDirectoryName(parm[17]);
             stli.setTargetSmbAddr(parm[18]);
             if (!parm[19].equals("")) {
-                int port_number=445;
+                int port_number=Integer.valueOf(SyncTaskItem.SYNC_FOLDER_SMB_PORT_DEFAULT);
                 try {
                     port_number=Integer.parseInt(parm[19]);
                     stli.setMasterSmbPort(parm[19]);
@@ -6427,11 +6427,11 @@ public class SyncTaskUtil {
                     stli.setSyncOptionWifiStatusOption(parm[37]);
                 } else {
                     stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_DEFAULT );
-                    putTaskListValueErrorMessage(util, "WiFi status option", "Conn any AP");
+                    putTaskListValueErrorMessage(util, "WiFi status option", SyncTaskItem.SYNC_WIFI_STATUS_WIFI_DEFAULT_DESCRIPTION);
                 }
             } catch(Exception e) {
                 stli.setSyncOptionWifiStatusOption(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_DEFAULT );
-                putTaskListValueErrorMessage(util, "WiFi status option", "Conn any AP");
+                putTaskListValueErrorMessage(util, "WiFi status option", SyncTaskItem.SYNC_WIFI_STATUS_WIFI_DEFAULT_DESCRIPTION);
             }
 
             stli.setLastSyncTime(parm[38]);
@@ -6439,12 +6439,12 @@ public class SyncTaskUtil {
                 if (isValidTaskItemValue(SyncTaskItem.SYNC_STATUS_LIST, Integer.parseInt(parm[39]))) {
                     stli.setLastSyncResult(Integer.parseInt(parm[39]));
                 } else {
-                    stli.setLastSyncResult(SyncTaskItem.SYNC_STATUS_SUCCESS);
-                    putTaskListValueErrorMessage(util, "Last sync result", "Success");
+                    stli.setLastSyncResult(SyncTaskItem.SYNC_STATUS_DEFAULT);
+                    putTaskListValueErrorMessage(util, "Last sync result", SyncTaskItem.SYNC_STATUS_DEFAULT_DESCRIPTION);
                 }
             } catch(Exception e) {
-                stli.setLastSyncResult(SyncTaskItem.SYNC_STATUS_SUCCESS);
-                putTaskListValueErrorMessage(util, "Last sync result", "Success");
+                stli.setLastSyncResult(SyncTaskItem.SYNC_STATUS_DEFAULT);
+                putTaskListValueErrorMessage(util, "Last sync result", SyncTaskItem.SYNC_STATUS_DEFAULT_DESCRIPTION);
             }
 
             try {
@@ -6549,7 +6549,7 @@ public class SyncTaskUtil {
                     stli.setMasterSmbProtocol(parm[64]);
                 } else {
                     stli.setMasterSmbProtocol(SyncTaskItem.SYNC_FOLDER_SMB_PROTOCOL_DEFAULT);
-                    putTaskListValueErrorMessage(util, "Master SMB protocol", "SMB212");
+                    putTaskListValueErrorMessage(util, "Master SMB protocol", SyncTaskItem.SYNC_FOLDER_SMB_PROTOCOL_DEFAULT_DESCRIPTION);
                 }
             }
 
@@ -6558,7 +6558,7 @@ public class SyncTaskUtil {
                     stli.setTargetSmbProtocol(parm[65]);
                 } else {
                     stli.setTargetSmbProtocol(SyncTaskItem.SYNC_FOLDER_SMB_PROTOCOL_DEFAULT);
-                    putTaskListValueErrorMessage(util, "Target SMB protocol", "SMB212");
+                    putTaskListValueErrorMessage(util, "Target SMB protocol", SyncTaskItem.SYNC_FOLDER_SMB_PROTOCOL_DEFAULT_DESCRIPTION);
                 }
             }
 
@@ -6573,7 +6573,7 @@ public class SyncTaskUtil {
                         stli.setArchiveRetentionPeriod(Integer.parseInt(parm[70]));
                     } else {
                         stli.setArchiveRetentionPeriod(SyncTaskItem.PICTURE_ARCHIVE_RETAIN_FOR_A_DEFAULT);
-                        putTaskListValueErrorMessage(util, "Archive retention period", "180 Days");
+                        putTaskListValueErrorMessage(util, "Archive retention period", SyncTaskItem.PICTURE_ARCHIVE_RETAIN_FOR_A_DEFAULT_DESCRIPTION);
                     }
                 } catch(Exception e) {
                     stli.setArchiveRetentionPeriod(SyncTaskItem.PICTURE_ARCHIVE_RETAIN_FOR_A_DEFAULT);
@@ -6588,11 +6588,11 @@ public class SyncTaskUtil {
                         stli.setArchiveSuffixOption(parm[72]);
                     } else {
                         stli.setArchiveSuffixOption(String.valueOf(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT));
-                        putTaskListValueErrorMessage(util, "Archive suffix digit", SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT);
+                        putTaskListValueErrorMessage(util, "Archive suffix digit", String.valueOf(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT));
                     }
                 } catch(Exception e) {
                     stli.setArchiveSuffixOption(String.valueOf(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT));
-                    putTaskListValueErrorMessage(util, "Archive suffix digit", SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT);
+                    putTaskListValueErrorMessage(util, "Archive suffix digit", String.valueOf(SyncTaskItem.PICTURE_ARCHIVE_SUFFIX_DIGIT_DEFAULT));
                 }
             }
 

--- a/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
@@ -212,9 +212,9 @@
         <string name="msgs_main_sync_profile">同期実行 (%s)</string>
         <string name="msgs_main_sync_profile_dlg_archive">アーカイブ</string>
         <string name="msgs_main_sync_profile_dlg_copy">コピー</string>
-        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">1</string>
-        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_10">10</string>
-        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_3">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_0">1</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_2">10</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_prompt">最終更新時刻の差（秒）</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_internal">マスターフォルダーとターゲットフォルダーの両方が内部ストレージでディレクトリーが重複しています。どちらかを違うディレクトリーに変更してください。</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_same_dir">マスターフォルダーとターゲットフォルダーで同じディレクトリにアクセスします、どちらかのディレクトリを変更するかディレクトリフィルターを指定してください。</string>

--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -214,9 +214,9 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_main_sync_profile">Sync task (%s)</string>
         <string name="msgs_main_sync_profile_dlg_archive">Archive</string>
         <string name="msgs_main_sync_profile_dlg_copy">Copy</string>
-        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">1</string>
-        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_10">10</string>
-        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_3">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_0">1</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_1">3</string>
+        <string name="msgs_main_sync_profile_dlg_diff_time_value_option_2">10</string>
         <string name="msgs_main_sync_profile_dlg_diff_time_value_option_prompt">Last time of tolerance(Sec)</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_internal">Duplicate directory names exist at both internal storage source and destination.  Source and destination directory names must be different.</string>
         <string name="msgs_main_sync_profile_dlg_invalid_master_target_cobination_same_dir">Duplicate directory names exist at both source and destination.  Source and destination directory names must be different.</string>


### PR DESCRIPTION
- optimize and fix default values setting code
- bug fix: on Android SDK 27, if location service is disabled, when we create a task with smb share, a prompt asks to set the WIFI AP to "Private address". If we answer ok, the Wifi AP was regardless set to "Any AP"