### PR TITLE
Try color green on success message + 2 other cosmetic requests

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncMessage.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncMessage.java
@@ -32,6 +32,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
+import android.graphics.Color;
 import com.sentaroh.android.Utilities.ThemeColorList;
 import com.sentaroh.android.Utilities.ThemeUtil;
 
@@ -156,6 +157,13 @@ public class AdapterSyncMessage extends ArrayAdapter<SyncMessageItem> {
                 holder.tv_row_time.setTextColor(mThemeColorList.text_color_error);
                 holder.tv_row_date.setTextColor(mThemeColorList.text_color_error);
                 holder.tv_row_msg.setTextColor(mThemeColorList.text_color_error);
+                holder.tv_row_time.setText(o.getTime());
+                holder.tv_row_date.setText(o.getDate());
+                holder.tv_row_msg.setText(o.getMessage());
+            } else if (cat.equals("S")) {
+                holder.tv_row_time.setTextColor(mThemeColorList.text_color_error);
+                holder.tv_row_date.setTextColor(mThemeColorList.text_color_error);
+                holder.tv_row_msg.setTextColor(Color.GREEN);
                 holder.tv_row_time.setText(o.getTime());
                 holder.tv_row_date.setText(o.getDate());
                 holder.tv_row_msg.setText(o.getMessage());

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -589,6 +589,7 @@ public class SyncThread extends Thread {
 
         if (sync_result == SyncTaskItem.SYNC_STATUS_SUCCESS) {
             showMsg(mStwa, false, sti.getSyncTaskName(), "I", "", "", mGp.appContext.getString(R.string.msgs_mirror_task_result_ok));
+            showMsg(mStwa, false, sti.getSyncTaskName(), "S", "", "", mGp.appContext.getString(R.string.msgs_mirror_task_result_ok));
         } else if (sync_result == SyncTaskItem.SYNC_STATUS_WARNING) {
             showMsg(mStwa, false, sti.getSyncTaskName(), "I", "", "", mGp.appContext.getString(R.string.msgs_mirror_task_result_ok));
         } else if (sync_result == SyncTaskItem.SYNC_STATUS_CANCEL) {


### PR DESCRIPTION
Alpha example code. When scheduling multiple tasks, results of first tasks are hard to spot inside the messages list
Color green the sync success message