### PR TITLE
Various fixes

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncHistory.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncHistory.java
@@ -233,8 +233,8 @@ public class AdapterSyncHistory extends ArrayAdapter<SyncHistoryItem> {
                     holder.tv_error.setTextColor(mThemeColorList.text_color_warning);
                 }
 
-                holder.tv_et.setText(o.sync_elapsed_time);
-                holder.tv_tr.setText(o.sync_transfer_speed);
+                holder.tv_et.setText(String.format(" %s", o.sync_elapsed_time));
+                holder.tv_tr.setText(String.format(" %s", o.sync_transfer_speed));
 
                 holder.tv_status.setText(st_text);
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncHistoryItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncHistoryItem.java
@@ -30,7 +30,7 @@ class SyncHistoryItem {
     public String sync_time = null;
     public String sync_elapsed_time = null;
     public String sync_prof = "";
-    public String sync_transfer_speed = null;
+    public String sync_transfer_speed = "";
     public String sync_req = "";
     public boolean sync_test_mode = false;
     public int sync_status = SYNC_STATUS_SUCCESS;

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -60,6 +60,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.math.RoundingMode;
 import java.math.BigDecimal;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -67,11 +68,14 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Socket;
 import java.text.SimpleDateFormat;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -559,10 +563,19 @@ public class SyncThread extends Thread {
     }
 
     private void postProcessSyncResult(SyncTaskItem sti, int sync_result, long et) {
-        int t_et_sec = (int) (et / 1000);
-        int t_et_ms = (int) (et - (t_et_sec * 1000));
+        long msecs = et;
+        long hr = TimeUnit.MILLISECONDS.toHours(msecs); msecs -= TimeUnit.HOURS.toMillis(hr);
+        long min = TimeUnit.MILLISECONDS.toMinutes(msecs); msecs -= TimeUnit.MINUTES.toMillis(min);
+        long sec = TimeUnit.MILLISECONDS.toSeconds(msecs); msecs -= TimeUnit.SECONDS.toMillis(sec);
+        long ms = TimeUnit.MILLISECONDS.toMillis(msecs);
 
-        String sync_et = String.valueOf(t_et_sec) + "." + String.format("%3d", t_et_ms).replaceAll(" ", "0");
+        String sync_et = null;
+        if (hr != 0)
+            sync_et = String.format("%2d:%02d:%02d", hr, min, sec);
+        else if (min != 0)
+            sync_et = String.format("%2d min %2d.%02d sec", min, sec, ms/10);
+        else
+            sync_et = String.format("%2d.%03d sec", sec, ms);
 
         String error_msg = "";
         if (sync_result == SyncTaskItem.SYNC_STATUS_ERROR || sync_result == SyncTaskItem.SYNC_STATUS_WARNING) {
@@ -3363,46 +3376,42 @@ public class SyncThread extends Thread {
         }
     }
 
-    ;
-
     static final public String calTransferRate(long tb, long tt) {
         String tfs = null;
+        String units = null;
         BigDecimal bd_tr;
 //		Log.v("","byte="+tb+", time="+tt);
 
-        if (tb == 0) return "0Bytes/sec";
+        if (tb == 0) return " 0 Bytes/sec";
 
-        long n_tt = (tt == 0) ? 1 : tt;
+        if (tt == 0) return " N/A"; // elapsed time 0 msec
+    
+        BigDecimal dfs = new BigDecimal(tb * 1.000000);
+        BigDecimal dft1 = new BigDecimal(tt * 1.000);
+        BigDecimal dft2 = new BigDecimal(1000.000);
+        BigDecimal dft = new BigDecimal("0.000000");
+        dft = dft1.divide(dft2); // convert elapsed time from msec to sec
+        BigDecimal bd_tr1 = dfs.divide(dft, 6, BigDecimal.ROUND_HALF_UP); // transfer speed in bytes /sec
 
-        if (tb > (1024)) {//KB
-            BigDecimal dfs1 = new BigDecimal(tb * 1.000);
-            BigDecimal dfs2 = new BigDecimal(1024 * 1.000);
-            BigDecimal dfs3 = new BigDecimal("0.000000");
-            dfs3 = dfs1.divide(dfs2);
-            BigDecimal dft1 = new BigDecimal(n_tt * 1.000);
-            BigDecimal dft2 = new BigDecimal(1000.000);
-            BigDecimal dft3 = new BigDecimal("0.000000");
-            dft3 = dft1.divide(dft2);
-            bd_tr = dfs3.divide(dft3, 2, BigDecimal.ROUND_HALF_UP);
-            tfs = bd_tr + " KBytes/sec";
-//			Log.v("","dfs1="+dfs1+", dfs2="+dfs2+", dfs3="+dfs3);
-//			Log.v("","dft1="+dft1+", dft2="+dft2+", dft3="+dft3);
-//			Log.v("","bd_tr="+bd_tr+", tfs="+tfs);
-        } else {
-            BigDecimal dfs1 = new BigDecimal(tb * 1.000);
-            BigDecimal dfs2 = new BigDecimal(1024 * 1.000);
-            BigDecimal dfs3 = new BigDecimal("0.000000");
-            dfs3 = dfs1.divide(dfs2);
-            BigDecimal dft1 = new BigDecimal(n_tt * 1.000);
-            BigDecimal dft2 = new BigDecimal(1000.000);
-            BigDecimal dft3 = new BigDecimal("0.000000");
-            dft3 = dft1.divide(dft2);
-            bd_tr = dfs3.divide(dft3, 2, BigDecimal.ROUND_HALF_UP);
-            tfs = bd_tr + " Bytes/sec";
-//			Log.v("","dfs1="+dfs1+", dfs2="+dfs2+", dfs3="+dfs3);
-//			Log.v("","dft1="+dft1+", dft2="+dft2+", dft3="+dft3);
-//			Log.v("","bd_tr="+bd_tr+", tfs="+tfs);
+        if (bd_tr1.compareTo(new BigDecimal(1048576)) >= 0) {//  MB/sec (transfer speed >= 1024 * 1024 bytes)
+            units = " MBytes/sec";
+            BigDecimal bd_tr2 = new BigDecimal(1024 * 1024 * 1.000000);
+            bd_tr = bd_tr1.divide(bd_tr2, 2, BigDecimal.ROUND_HALF_UP);
+        } else if (bd_tr1.compareTo(new BigDecimal(1024)) >= 0) { // KB/sec (transfer speed >= 1024 bytes)
+            units = " KBytes/sec";
+            BigDecimal bd_tr2 = new BigDecimal(1024 * 1.000000);
+            bd_tr = bd_tr1.divide(bd_tr2, 1, BigDecimal.ROUND_HALF_UP);
+        } else { // Bytes/sec
+            units = " Bytes/sec";
+            bd_tr = bd_tr1.setScale(0, RoundingMode.HALF_UP);
         }
+
+        // proper formatting and grouping
+        DecimalFormatSymbols formatSymbols = new DecimalFormatSymbols();
+        formatSymbols.setDecimalSeparator('.');
+        formatSymbols.setGroupingSeparator(' ');
+        DecimalFormat formatter = new DecimalFormat("###,###.###", formatSymbols);
+        tfs = formatter.format(bd_tr) + units;
 
         return tfs;
     }

--- a/SMBSync2/src/main/res/layout-land/sync_history_list_item_view.xml
+++ b/SMBSync2/src/main/res/layout-land/sync_history_list_item_view.xml
@@ -139,6 +139,8 @@
 	            android:text="Activity"
 	            tools:ignore="HardcodedText" />
 
+	    </LinearLayout>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" >
@@ -158,7 +160,6 @@
                     android:maxLines="1"
                     android:text="1000000.00"
                     tools:ignore="HardcodedText" />
-            </LinearLayout>
 	    </LinearLayout>
 	    
 	    <TextView

--- a/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
@@ -187,8 +187,8 @@
         <string name="msgs_main_sync_history_count_retry">リトライ:</string>
         <string name="msgs_main_sync_history_del_conf_all_history">全ての履歴を削除しますか?</string>
         <string name="msgs_main_sync_history_del_conf_selected_history">下記の履歴を削除しますか?</string>
-        <string name="msgs_main_sync_history_elapsed_time">処理時間(秒):</string>
-        <string name="msgs_main_sync_history_transfer_speed">平均転送率 :</string>
+        <string name="msgs_main_sync_history_elapsed_time">処理時間:</string>
+        <string name="msgs_main_sync_history_transfer_speed">平均転送率:</string>
         <string name="msgs_main_sync_history_mode">モード:</string>
         <string name="msgs_main_sync_history_mode_normal">通常</string>
         <string name="msgs_main_sync_history_mode_test">テスト</string>
@@ -553,7 +553,7 @@
         <string name="msgs_mirror_task_file_moved">ファイルを移動しました。</string>
         <string name="msgs_mirror_task_file_replaced">ファイルを上書きコピーしました。</string>
         <string name="msgs_mirror_task_master_not_found">マスターのファイルまたはディレクトリーが見つかりません。</string>
-        <string name="msgs_mirror_task_no_of_copy" formatted="false">コピー=%s, 削除=%s, 無視=%s, 経過時間=%s(秒)</string>
+        <string name="msgs_mirror_task_no_of_copy" formatted="false">コピー=%s, 削除=%s, 無視=%s, 経過時間=%s</string>
         <string name="msgs_mirror_task_result_cancel">同期タスクがキャンセルされました。</string>
         <string name="msgs_mirror_task_result_error_ended">同期タスクはエラーで終了しました。</string>
         <string name="msgs_mirror_task_result_error_skipped">エラー処理オプションの設定によりエラーを無視しました。</string>

--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -189,8 +189,8 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_main_sync_history_count_retry">Retry:</string>
         <string name="msgs_main_sync_history_del_conf_all_history">Do you want to delete all history?</string>
         <string name="msgs_main_sync_history_del_conf_selected_history">Do you want to delete following history?</string>
-        <string name="msgs_main_sync_history_elapsed_time">Elapsed time(Sec):</string>
-        <string name="msgs_main_sync_history_transfer_speed">Average transfer rate :</string>
+        <string name="msgs_main_sync_history_elapsed_time">Elapsed time:</string>
+        <string name="msgs_main_sync_history_transfer_speed">Average transfer rate:</string>
         <string name="msgs_main_sync_history_mode">Mode:</string>
         <string name="msgs_main_sync_history_mode_normal">Normal</string>
         <string name="msgs_main_sync_history_mode_test">Test</string>
@@ -555,7 +555,7 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_mirror_task_file_moved">File moved.</string>
         <string name="msgs_mirror_task_file_replaced">File overwritten.</string>
         <string name="msgs_mirror_task_master_not_found">Source file or directory not found.</string>
-        <string name="msgs_mirror_task_no_of_copy" formatted="false"># of copies=%s, # of deletes=%s, # of ignores=%s, Elapsed time=%s(Sec)</string>
+        <string name="msgs_mirror_task_no_of_copy" formatted="false"># of copies=%s, # of deletes=%s, # of ignores=%s, Elapsed time=%s</string>
         <string name="msgs_mirror_task_result_cancel">Sync task cancelled.</string>
         <string name="msgs_mirror_task_result_error_ended">Sync task ended with error.</string>
         <string name="msgs_mirror_task_result_error_skipped">Ignore errors enabled.  Error ignored.</string>


### PR DESCRIPTION
Please look at the 2 commits below: the code is properly working:

**commit 1:**
- bug fix: display transfer rate in history when in land layout was broken

**commit 2:**
- fix transfer rate was wrongly calculated when it was less than 1024 bytes
- support transfer rates of MegaByte/sec format
- fix missing spaces when displaying transfer rate / elapsed time in History
- properly format transfer rates for readability
- elapsed time was displayed in sssssss.mmm: properly format it to hh:mn.ss / mn.ss.mm / ss.mmm depending on duration in hours/mn/sec/msec