### PR TITLE
Bug fix: properly allow user set smb port

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ReadSmbFilelist.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ReadSmbFilelist.java
@@ -282,8 +282,8 @@ public class ReadSmbFilelist implements Runnable {
             if (resolved_addr.contains(":")) remoteUrl="smb://"+"["+resolved_addr+"]"+"/"+t_share;
             else remoteUrl="smb://"+resolved_addr+"/"+t_share;
         } else {
-            if (resolved_addr.contains(":")) remoteUrl="smb://"+"["+resolved_addr+"]"+":"+remoteHostPort+"/"+t_share;
-            else remoteUrl="smb://"+resolved_addr+":"+remoteHostPort+"/"+t_share;
+            if (resolved_addr.contains(":")) remoteUrl="smb://"+"["+resolved_addr+"]"+remoteHostPort+"/"+t_share;
+            else remoteUrl="smb://"+resolved_addr+remoteHostPort+"/"+t_share;
         }
         mUtil.addDebugMsg(1, "I", "buildRemoteUrl result="+remoteUrl);
     }


### PR DESCRIPTION
Task editor: If we specify the SMB port manually (exp 445), listing the shares and selecting folders in remote sbm server fails.
However, the sync was properly executed if we select Share name and Folder name manually in the Task Editor.