### PR TITLE
Fix extra leading spaces if seconds are one digit + msec display

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -571,7 +571,7 @@ public class SyncThread extends Thread {
 
         String sync_et = null;
         if (hr != 0) sync_et = String.format("%2d:%02d:%02d", hr, min, sec);
-        else if (min != 0) sync_et = String.format("%2d min %2d.%02d sec", min, sec, ms/10);
+        else if (min != 0) sync_et = String.format("%2d min %d.%03d sec", min, sec, ms);
         else sync_et = String.format("%2d.%03d sec", sec, ms);
 
         String error_msg = "";


### PR DESCRIPTION
- fix extra space between min and seconds if seconds were only one digit
- the display of 3.52 seconds in not clear, so it is best to keep 3.520 seconds for the 520 mseconds