### PR TITLE
Display elapsed time adjustments

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -570,9 +570,9 @@ public class SyncThread extends Thread {
         long ms = TimeUnit.MILLISECONDS.toMillis(msecs);
 
         String sync_et = null;
-        if (hr != 0) sync_et = String.format("%2d:%02d:%02d", hr, min, sec);
-        else if (min != 0) sync_et = String.format("%2d min %2d.%02d sec", min, sec, ms/10);
-        else sync_et = String.format("%2d.%03d sec", sec, ms);
+        if (hr != 0) sync_et = String.format("%02d:%02d:%02d", hr, min, sec);
+        else if (min != 0) sync_et = String.format("%d min %d.%03d sec", min, sec, ms);
+        else sync_et = String.format("%d.%03d sec", sec, ms);
 
         String error_msg = "";
         if (sync_result == SyncTaskItem.SYNC_STATUS_ERROR || sync_result == SyncTaskItem.SYNC_STATUS_WARNING) {


### PR DESCRIPTION
- fix extra space between min and seconds if seconds were only one digit
- the display of 3.52 seconds in not clear, so it is best to keep 3.520 seconds for the 520 mseconds
- if hours: 01:03:05 is universally clear and used
- if minutes: 3 min 5.210 sec (no 0 or spaces padding for minutes and seconds)
- if seconds: 3.510 sec (no 0 or space padding for seconds)