### PR TITLE
Hide delete master folder option on irrelevant sync modes

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3320,7 +3320,7 @@ public class SyncTaskEditor extends DialogFragment {
         ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write.setChecked(n_sti.isSyncOptionDoNotUseRenameWhenSmbFileWrite());
         setCtvListenerForEditSyncTask(ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write, type, n_sti, dlg_msg);
 
-        final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_remove_directory_if_empty_when_move);
+        final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
         ctv_sync_remove_master_if_empty.setChecked(n_sti.isSyncOptionMoveOnlyRemoveMasterDirectoryIfEmpty());
         setCtvListenerForEditSyncTask(ctv_sync_remove_master_if_empty, type, n_sti, dlg_msg);
 
@@ -3603,9 +3603,6 @@ public class SyncTaskEditor extends DialogFragment {
             ctv_auto.setEnabled(true);
         }
 
-        final LinearLayout ll_last_mod_force_smbsync = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_use_smbsync_last_mod_time_view);
-        final LinearLayout ll_use_file_last_mod = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_sync_diff_use_last_mod_time_view);
-        final LinearLayout ll_last_mod_allowed_time = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_diff_file_determin_time_value_view);
         final CheckedTextView ctvDeterminChangedFileSizeGtTarget = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_file_size_greater_than_target);
         ctvDeterminChangedFileSizeGtTarget.setChecked(n_sti.isSyncDifferentFileSizeGreaterThanTagetFile());
         final CheckedTextView ctvDiffUseFileSize = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_use_file_size);
@@ -4364,7 +4361,7 @@ public class SyncTaskEditor extends DialogFragment {
 
         final CheckedTextView ctv_sync_allow_global_ip_addr = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_sync_allow_global_ip_address);
 
-        final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_remove_directory_if_empty_when_move);
+        final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
 
         final Spinner spinnerSyncDiffTimeValue = (Spinner) dialog.findViewById(R.id.edit_sync_task_option_spinner_diff_file_determin_time_value);
         final Button btn_ok = (Button) dialog.findViewById(R.id.edit_profile_sync_dlg_btn_ok);
@@ -4566,10 +4563,12 @@ public class SyncTaskEditor extends DialogFragment {
 
         final LinearLayout ll_diff_time_allowed_time = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_diff_file_determin_time_value_view);
 
+        final LinearLayout ll_sync_remove_master_if_empty = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_remove_directory_if_empty_when_move_view);
+
         final CheckedTextView ctvDeterminChangedFileSizeGtTarget = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_file_size_greater_than_target);
         final CheckedTextView ctvDiffUseFileSize = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_use_file_size);
 
-        final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_remove_directory_if_empty_when_move);
+        final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
 
         final LinearLayout ll_edit_sync_tak_option_keep_conflict_file=(LinearLayout)mDialog.findViewById(R.id.edit_sync_task_option_twoway_sync_keep_conflic_file_view);
         final LinearLayout ll_spinnerTwoWaySyncConflictRule=(LinearLayout)mDialog.findViewById(R.id.edit_sync_task_option_twoway_sync_conflict_file_rule_view);
@@ -4582,6 +4581,15 @@ public class SyncTaskEditor extends DialogFragment {
         ll_edit_sync_tak_option_keep_conflict_file.setVisibility(LinearLayout.GONE);
         ll_spinnerTwoWaySyncConflictRule.setVisibility(LinearLayout.GONE);
         swap_master_target.setVisibility(Button.VISIBLE);
+
+        if (n_sti.getSyncTaskType().equals(SyncTaskItem.SYNC_TASK_TYPE_MOVE)) {
+            ll_sync_remove_master_if_empty.setVisibility(CheckedTextView.VISIBLE);
+        }
+        else {
+            ll_sync_remove_master_if_empty.setVisibility(CheckedTextView.GONE);
+            ctv_sync_remove_master_if_empty.setChecked(false);
+        }
+
         if (n_sti.getSyncTaskType().equals(SyncTaskItem.SYNC_TASK_TYPE_ARCHIVE)) {
             ll_file_filter.setVisibility(LinearLayout.GONE);
 

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
@@ -547,12 +547,12 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/edit_sync_task_option_remove_directory_if_empty_when_move_view"
+                android:id="@+id/edit_sync_task_option_ll_remove_directory_if_empty_when_move_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
                 <CheckedTextView
-                    android:id="@+id/edit_sync_task_option_remove_directory_if_empty_when_move"
+                    android:id="@+id/edit_sync_task_option_ctv_remove_directory_if_empty_when_move"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:checkMark="?android:attr/listChoiceIndicatorMultiple"


### PR DESCRIPTION
- only show Delete master folder option when sync task is MOVE
- remove useless code lines