### PR TITLE
Potential Bug fixes: reset offsets and apply in exported settings

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3672,8 +3672,12 @@ public class SyncTaskEditor extends DialogFragment {
                     }
                 } else {
                     ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
+                    setSpinnerSyncTaskDiffTimeValue(spinnerSyncDiffTimeValue, n_sti.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT);
                     ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
                     ctv_ignore_dst_difference.setChecked(false);
+                    n_sti.initOffsetOfDst();
+                    setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
+                    // setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.SYNC_OPTION_OFFSET_OF_DST_DEFAULT);
                 }
                 checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
             }
@@ -3688,6 +3692,9 @@ public class SyncTaskEditor extends DialogFragment {
                     ll_offset_dst_view.setVisibility(LinearLayout.VISIBLE);
                 } else {
                     ll_offset_dst_view.setVisibility(LinearLayout.GONE);
+                    n_sti.initOffsetOfDst();
+                    setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
+                    // setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.SYNC_OPTION_OFFSET_OF_DST_DEFAULT);
                 }
                 checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
             }

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
@@ -239,9 +239,9 @@ class SyncTaskItem implements Serializable, Cloneable {
         initOffsetOfDst();
     }
 
-    private void initOffsetOfDst() {
+    public void initOffsetOfDst() {
         if (TimeZone.getDefault().useDaylightTime()) setSyncOptionOffsetOfDst(TimeZone.getDefault().getDSTSavings()/(60*1000));
-        else setSyncOptionOffsetOfDst(60);
+        else setSyncOptionOffsetOfDst(SYNC_OPTION_OFFSET_OF_DST_DEFAULT);
     }
 
     public String getSyncTaskName() {return syncTasｋName;}


### PR DESCRIPTION
When compare by time difference was unchecked, time_diff_value and dst_offset were hidden but their values were kept at previous setting, in memory and in exported settings file
Properly reset values to default so that they are saved in exported settings and applied in memory