### PR TITLE
Fix dependent menu view (incomplete patch, please read comment)

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3672,8 +3672,12 @@ public class SyncTaskEditor extends DialogFragment {
                     }
                 } else {
                     ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
+                    setSpinnerSyncTaskDiffTimeValue(spinnerSyncDiffTimeValue, n_sti.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT);
                     ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
                     ctv_ignore_dst_difference.setChecked(false);
+                    n_sti.initOffsetOfDst();
+                    setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
+                    // setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.SYNC_OPTION_OFFSET_OF_DST_DEFAULT);
                 }
                 checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
             }
@@ -3688,6 +3692,9 @@ public class SyncTaskEditor extends DialogFragment {
                     ll_offset_dst_view.setVisibility(LinearLayout.VISIBLE);
                 } else {
                     ll_offset_dst_view.setVisibility(LinearLayout.GONE);
+                    n_sti.initOffsetOfDst();
+                    setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
+                    // setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.SYNC_OPTION_OFFSET_OF_DST_DEFAULT);
                 }
                 checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
             }
@@ -4562,12 +4569,18 @@ public class SyncTaskEditor extends DialogFragment {
         final LinearLayout ll_ctvDiffUseFileSize = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_sync_diff_use_file_size);
         final LinearLayout ll_ctDeterminChangedFileByTime = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_sync_diff_use_last_mod_time_view);
 
-        final LinearLayout ll_diff_time_allowed_time = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_diff_file_determin_time_value_view);
+        final LinearLayout ll_DeterminChangedFileByTime_dependant_view=(LinearLayout)mDialog.findViewById(R.id.edit_sync_task_option_sync_diff_use_last_mod_time_dependant_view);
+        final Spinner spinnerSyncDiffTimeValue = (Spinner) mDialog.findViewById(R.id.edit_sync_task_option_spinner_diff_file_determin_time_value);
+        final Spinner spinnerSyncDstOffsetValue = (Spinner) mDialog.findViewById(R.id.edit_sync_task_option_spinner_offset_daylight_saving_time_value);
+
         final LinearLayout ll_sync_remove_master_if_empty = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_remove_directory_if_empty_when_move_view);
 
+        final CheckedTextView ctvDoNotResetFileLastMod = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_do_mot_reset_file_last_mod_time);
 
         final CheckedTextView ctvDeterminChangedFileSizeGtTarget = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_file_size_greater_than_target);
         final CheckedTextView ctvDiffUseFileSize = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_use_file_size);
+        final CheckedTextView ctv_never_overwrite_target_file_newer_than_the_master_file = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_never_overwrite_target_file_if_it_is_newer_than_the_master_file);
+        final CheckedTextView ctv_ignore_dst_difference = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_ignore_dst_difference);
 
         final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
 
@@ -4600,9 +4613,14 @@ public class SyncTaskEditor extends DialogFragment {
             ll_ctvUseSmbsyncLastMod.setVisibility(CheckedTextView.GONE);
 
             ll_ctvDiffUseFileSize.setVisibility(CheckedTextView.GONE);
-            ll_ctDeterminChangedFileByTime.setVisibility(CheckedTextView.GONE);
 
-            ll_diff_time_allowed_time.setVisibility(CheckedTextView.GONE);
+            ll_ctDeterminChangedFileByTime.setVisibility(CheckedTextView.GONE);
+            ll_DeterminChangedFileByTime_dependant_view.setVisibility(CheckedTextView.GONE);
+            setSpinnerSyncTaskDiffTimeValue(spinnerSyncDiffTimeValue, n_sti.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT);
+            ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
+            ctv_ignore_dst_difference.setChecked(false);
+            n_sti.initOffsetOfDst();
+            setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
         } else {
             ll_file_filter.setVisibility(LinearLayout.VISIBLE);
 
@@ -4617,11 +4635,25 @@ public class SyncTaskEditor extends DialogFragment {
             if (ctvDiffUseFileSize.isChecked() && ctvDeterminChangedFileSizeGtTarget.isChecked()) {
                 ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.GONE);
                 ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.GONE);
-                ll_diff_time_allowed_time.setVisibility(LinearLayout.GONE);
+                ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
+                setSpinnerSyncTaskDiffTimeValue(spinnerSyncDiffTimeValue, n_sti.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT);
+                ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
+                ctv_ignore_dst_difference.setChecked(false);
+                n_sti.initOffsetOfDst();
+                setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
+            } else if (ctvDoNotResetFileLastMod.isChecked() && n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB)) {
+                ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.GONE);
+                ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.GONE);
+                ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
+                setSpinnerSyncTaskDiffTimeValue(spinnerSyncDiffTimeValue, n_sti.SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT);
+                ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
+                ctv_ignore_dst_difference.setChecked(false);
+                n_sti.initOffsetOfDst();
+                setSpinnerSyncTaskDstOffsetValue(spinnerSyncDstOffsetValue, n_sti.getSyncOptionOffsetOfDst());
             } else {
                 ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.VISIBLE);
                 ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.VISIBLE);
-                ll_diff_time_allowed_time.setVisibility(LinearLayout.VISIBLE);
+                ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.VISIBLE);
             }
 
             if (n_sti.getSyncTaskType().equals(SyncTaskItem.SYNC_TASK_TYPE_SYNC)) {

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
@@ -239,9 +239,9 @@ class SyncTaskItem implements Serializable, Cloneable {
         initOffsetOfDst();
     }
 
-    private void initOffsetOfDst() {
+    public void initOffsetOfDst() {
         if (TimeZone.getDefault().useDaylightTime()) setSyncOptionOffsetOfDst(TimeZone.getDefault().getDSTSavings()/(60*1000));
-        else setSyncOptionOffsetOfDst(60);
+        else setSyncOptionOffsetOfDst(SYNC_OPTION_OFFSET_OF_DST_DEFAULT);
     }
 
     public String getSyncTaskName() {return syncTasｋName;}


### PR DESCRIPTION
- when "do not change destination file time option" is selected and Target is SMB: disable time difference compare options
- when Mode is Archive: DST settings and most time_diff dependent view could be still shown while time compare was off (Archive mode or when both "SizeDiff" and "source is larger" are set)
- fix DST offset and Time_Diff are properly reset and applied in settings when disabled
- fix time_diff dependent options were still shown when time_diff is hidden by  ctvDiffUseFileSize.isChecked() && ctvDeterminChangedFileSizeGtTarget.isChecked()