### PR TITLE
Proper fix to dependent views display

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3651,8 +3651,6 @@ public class SyncTaskEditor extends DialogFragment {
             }
         } else {
             ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
-            ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
-            ctv_ignore_dst_difference.setChecked(false);
             ll_offset_dst_view.setVisibility(LinearLayout.GONE);
         }
         ctDeterminChangedFileByTime.setOnClickListener(new OnClickListener() {
@@ -3669,8 +3667,6 @@ public class SyncTaskEditor extends DialogFragment {
                     }
                 } else {
                     ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
-                    ctv_never_overwrite_target_file_newer_than_the_master_file.setChecked(false);
-                    ctv_ignore_dst_difference.setChecked(false);
                 }
                 checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
             }
@@ -4544,16 +4540,16 @@ public class SyncTaskEditor extends DialogFragment {
 //        final CheckedTextView ctvSyncHiddenFile = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_sync_hidden_file);
 
         final LinearLayout ll_ctvProcessOverride = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_process_override_delete_file);
-        final LinearLayout ll_ctvConfirmOverride = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_confirm_override_delete_file);
+//        final LinearLayout ll_ctvConfirmOverride = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_confirm_override_delete_file);
 
 //        final CheckedTextView ctUseExtendedDirectoryFilter1 = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_sync_use_extended_filter1);
 //        final CheckedTextView ctvShowSpecialOption = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_show_special_option);
-        final LinearLayout ll_ctvDoNotResetFileLasyMod = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_do_mot_reset_file_last_mod_time);
-        final CheckedTextView ctvDoNotResetRemoteFile = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_do_mot_reset_file_last_mod_time);
+        final LinearLayout ll_ctvDoNotResetFileLastMod = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_do_mot_reset_file_last_mod_time);
+//        final CheckedTextView ctvDoNotResetRemoteFile = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_do_mot_reset_file_last_mod_time);
 
         final LinearLayout ll_ctvUseSmbsyncLastMod = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_use_smbsync_last_mod_time_view);
         final CheckedTextView ctvUseSmbsyncLastMod = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_use_smbsync_last_mod_time);
-        final CheckedTextView ctv_ignore_dst_difference = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_ignore_dst_difference);
+//        final CheckedTextView ctv_ignore_dst_difference = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_ignore_dst_difference);
 //        final CheckedTextView ctvRetry = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_retry_if_error_occured);
 //        final CheckedTextView ctvSyncUseRemoteSmallIoArea = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_sync_use_remote_small_io_area);
 //        final CheckedTextView ctvTestMode = (CheckedTextView) dialog.findViewById(R.id.edit_sync_task_option_ctv_sync_test_mode);
@@ -4563,7 +4559,6 @@ public class SyncTaskEditor extends DialogFragment {
         final CheckedTextView ctDeterminChangedFileByTime = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_use_last_mod_time);
         final LinearLayout ll_DeterminChangedFileByTime_dependant_view=(LinearLayout)mDialog.findViewById(R.id.edit_sync_task_option_sync_diff_use_last_mod_time_dependant_view);
 
-        final LinearLayout ll_diff_time_allowed_time = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_diff_file_determin_time_value_view);
         final LinearLayout ll_sync_remove_master_if_empty = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_remove_directory_if_empty_when_move_view);
 
 
@@ -4591,49 +4586,43 @@ public class SyncTaskEditor extends DialogFragment {
             ctv_sync_remove_master_if_empty.setChecked(false);
         }
 
+        if (!n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_INTERNAL)) {
+            ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.GONE);
+            ctvUseSmbsyncLastMod.setChecked(false);
+        } else ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.VISIBLE);
+
         if (n_sti.getSyncTaskType().equals(SyncTaskItem.SYNC_TASK_TYPE_ARCHIVE)) {
             ll_file_filter.setVisibility(LinearLayout.GONE);
 
             ll_ctvProcessOverride.setVisibility(CheckedTextView.GONE);
 //            ll_ctvConfirmOverride.setVisibility(CheckedTextView.GONE);
 
-            ll_ctvDoNotResetFileLasyMod.setVisibility(CheckedTextView.GONE);
+            ll_ctvDoNotResetFileLastMod.setVisibility(CheckedTextView.GONE);
+            ll_ctvDiffUseFileSize.setVisibility(CheckedTextView.GONE);
+
             ll_ctvUseSmbsyncLastMod.setVisibility(CheckedTextView.GONE);
 
-            ll_ctvDiffUseFileSize.setVisibility(CheckedTextView.GONE);
             ll_ctDeterminChangedFileByTime.setVisibility(CheckedTextView.GONE);
-
-            ll_diff_time_allowed_time.setVisibility(CheckedTextView.GONE);
+            ll_DeterminChangedFileByTime_dependant_view.setVisibility(CheckedTextView.GONE);
         } else {
             ll_file_filter.setVisibility(LinearLayout.VISIBLE);
 
             ll_ctvProcessOverride.setVisibility(CheckedTextView.VISIBLE);
 //            ll_ctvConfirmOverride.setVisibility(CheckedTextView.VISIBLE);
 
-            ll_ctvDoNotResetFileLasyMod.setVisibility(CheckedTextView.VISIBLE);
-            ll_ctvUseSmbsyncLastMod.setVisibility(CheckedTextView.VISIBLE);
+            ll_ctvDoNotResetFileLastMod.setVisibility(CheckedTextView.VISIBLE);
 
             ll_ctvDiffUseFileSize.setVisibility(CheckedTextView.VISIBLE);
 
             if (ctvDiffUseFileSize.isChecked() && ctvDeterminChangedFileSizeGtTarget.isChecked()) {
                 ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.GONE);
                 ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.GONE);
-                ll_diff_time_allowed_time.setVisibility(LinearLayout.GONE);
+                ctDeterminChangedFileByTime.setChecked(false); // mandatory if we want that this option forces a compare by size only mode, no checks inside code to bypass time diff if sizes are the same
+                ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
             } else {
-                if (ctvDoNotResetRemoteFile.isChecked()) {
-                    ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.GONE);
-                    ctvUseSmbsyncLastMod.setChecked(false);
-                    ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.GONE);
-                    ctDeterminChangedFileByTime.setChecked(false);
-                    ll_diff_time_allowed_time.setVisibility(LinearLayout.GONE);
-                    ctv_ignore_dst_difference.setChecked(false);
-                } else {
-                    ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.VISIBLE);
-                    ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.VISIBLE);
-                    ll_diff_time_allowed_time.setVisibility(LinearLayout.VISIBLE);
-                    if (ctDeterminChangedFileByTime.isChecked()) ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.VISIBLE);
-                    else ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
-                }
+                ll_ctDeterminChangedFileByTime.setVisibility(LinearLayout.VISIBLE);
+                if (ctDeterminChangedFileByTime.isChecked()) ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.VISIBLE);
+                else ll_DeterminChangedFileByTime_dependant_view.setVisibility(LinearLayout.GONE);
             }
 
             if (n_sti.getSyncTaskType().equals(SyncTaskItem.SYNC_TASK_TYPE_SYNC)) {

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -2512,7 +2512,7 @@ public class SyncThread extends Thread {
         if (exists_diff || (sti.isSyncOptionDifferentFileBySize() && length_diff > 0) || ac) {
             diff = true;
         } else {//Check lastModified()
-            if (!sti.isSyncDoNotResetFileLastModified() && sti.isSyncOptionDifferentFileByTime()) {
+            if (sti.isSyncOptionDifferentFileByTime()) {
                 if ((time_diff > stwa.syncDifferentFileAllowableTime)) { //LastModified was changed
                     if (sti.isSyncOptionIgnoreDstDifference()) {
                         if (Math.abs(time_diff-stwa.offsetOfDaylightSavingTime)<=stwa.syncDifferentFileAllowableTime) {

--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -399,7 +399,7 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_profile_sync_task_sync_option_sync_allow_global_ip_address">Allow sync with global IP addresses</string>
         <string name="msgs_profile_sync_task_sync_option_confirm_required">Confirm before overwrite/delete</string>
         <string name="msgs_profile_sync_task_sync_option_delete_first_when_mirror">Delete files prior to sync (Mirror method only)</string>
-        <string name="msgs_profile_sync_task_sync_option_diff_file_size_greater_than_target">Files are different only when the source is larger than the destination.</string>
+        <string name="msgs_profile_sync_task_sync_option_diff_file_size_greater_than_target">Files are considered different only if size of the source is larger than the destination (Size only compare, disables time difference).</string>
         <string name="msgs_profile_sync_task_sync_option_diff_file_use_file_size">Use file size to determine file difference</string>
         <string name="msgs_profile_sync_task_sync_option_diff_file_use_last_mod_time">Use time of last update to determine file difference</string>
         <string name="msgs_profile_sync_task_sync_option_empty_directory">Include empty directories</string>


### PR DESCRIPTION
Display of dependent items was broken
The previous commit broke copy only new files when "Do not set update time of destination file to match source" was unchecked, which is not desired

Fixes details:
- in Archive mode: properly hide "DST check option", "DST offset list" and "Do not overwrite destination file if newer than source"

- when both "Use file size to determin file diff" and "Files are diff only when the source is larger than the target" are checked: properly hide "DST check option", "DST offset list" and "Do not overwrite destination file if newer than source". Also adapt the menu translation and info

- when "Do not set update time of destination file to match source" is checked:
  + allow time_diff compare as it was before commit of 25.04.2020 (https://github.com/Sentaroh/SMBSync2/commit/6f847ddde28ca88f78984a1f3e6d7b0b0e387c52)
  + allow time_diff compare even if target is SMB: remove check in SyncThread.java file
  + reason to preserve it as it was: on most systems, external SDCARD and internal storage don't allow setTime/touch. We need to disable "Do not set update time of destination file". But we can still use time_diff and update new/added files only
  + if "Do not overwrite destination file if newer than source" is checked, time_diff sync will properly work for newer and added files
  + if target is Internal Storage: allow use of "Forced to get the last update date and time in SMBSync2" to use internal list to compare by time (see below)

- "Forced to get the last update date and time in SMBSync2": in code, it is only used if Target is Internal storage, so hide if target is not the internal storage. Other storage options always use auto-detect to set lastModifiedIsFunctional and override user choice. If target is SMB, lastModifiedIsFunctional is always true (in SyncThread.java file)

- Do not reset "DST option" and "File is Newer options" when hidden by dependent views