### PR TITLE
Group network options and hide them when needed

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3284,6 +3284,7 @@ public class SyncTaskEditor extends DialogFragment {
             }
         });
         final LinearLayout ll_wifi_condition_view = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_wifi_condition_view);
+        final LinearLayout ll_spinner_wifi_status = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_spinner_wifi_status);
         final LinearLayout ll_wifi_wl_view = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_wl_view);
         final LinearLayout ll_wifi_wl_ap_view = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ap_list_view);
         final LinearLayout ll_wifi_wl_address_view = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_address_list_view);
@@ -3321,6 +3322,17 @@ public class SyncTaskEditor extends DialogFragment {
         final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
         ctv_sync_remove_master_if_empty.setChecked(n_sti.isSyncOptionMoveOnlyRemoveMasterDirectoryIfEmpty());
         setCtvListenerForEditSyncTask(ctv_sync_remove_master_if_empty, type, n_sti, dlg_msg);
+
+        final CheckedTextView ctvRetry = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_retry_if_error_occured);
+        CommonUtilities.setCheckedTextView(ctvRetry);
+        if (n_sti.getSyncOptionRetryCount().equals("0")) ctvRetry.setChecked(false);
+        else ctvRetry.setChecked(true);
+        setCtvListenerForEditSyncTask(ctvRetry, type, n_sti, dlg_msg);
+
+        final CheckedTextView ctvSyncUseRemoteSmallIoArea = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_use_remote_small_io_area);
+        CommonUtilities.setCheckedTextView(ctvSyncUseRemoteSmallIoArea);
+        ctvSyncUseRemoteSmallIoArea.setChecked(n_sti.isSyncOptionUseSmallIoBuffer());
+        setCtvListenerForEditSyncTask(ctvSyncUseRemoteSmallIoArea, type, n_sti, dlg_msg);
 
         final Spinner spinnerSyncWifiStatus = (Spinner) mDialog.findViewById(R.id.edit_sync_task_option_spinner_wifi_status);
         setSpinnerSyncTaskWifiOption(spinnerSyncWifiStatus, n_sti.getSyncOptionWifiStatusOption());
@@ -3568,17 +3580,6 @@ public class SyncTaskEditor extends DialogFragment {
         CommonUtilities.setCheckedTextView(ctvUseSmbsyncLastMod);
         ctvUseSmbsyncLastMod.setChecked(n_sti.isSyncDetectLastModifiedBySmbsync());
         setCtvListenerForEditSyncTask(ctvUseSmbsyncLastMod, type, n_sti, dlg_msg);
-
-        final CheckedTextView ctvRetry = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_retry_if_error_occured);
-        CommonUtilities.setCheckedTextView(ctvRetry);
-        if (n_sti.getSyncOptionRetryCount().equals("0")) ctvRetry.setChecked(false);
-        else ctvRetry.setChecked(true);
-        setCtvListenerForEditSyncTask(ctvRetry, type, n_sti, dlg_msg);
-
-        final CheckedTextView ctvSyncUseRemoteSmallIoArea = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_use_remote_small_io_area);
-        CommonUtilities.setCheckedTextView(ctvSyncUseRemoteSmallIoArea);
-        ctvSyncUseRemoteSmallIoArea.setChecked(n_sti.isSyncOptionUseSmallIoBuffer());
-        setCtvListenerForEditSyncTask(ctvSyncUseRemoteSmallIoArea, type, n_sti, dlg_msg);
 
         final CheckedTextView ctvTestMode = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_test_mode);
         ctvTestMode.setOnClickListener(new OnClickListener() {

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
@@ -104,6 +104,50 @@
                 android:layout_gravity="center_vertical"
                 android:text="@string/msgs_profile_sync_task_sync_option_wifi_condition_title"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
+            <LinearLayout
+                android:id="@+id/edit_sync_task_option_ll_retry_if_error_occured"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+                <CheckedTextView
+                    android:id="@+id/edit_sync_task_option_ctv_retry_if_error_occured"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                    android:gravity="center_vertical"
+                    android:text="@string/msgs_profile_sync_task_sync_option_retry_if_error_occured"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                <include layout="@layout/divider_line1" />
+            </LinearLayout>
+            <LinearLayout
+                android:id="@+id/edit_sync_task_option_ll_sync_use_remote_small_io_area"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+                <CheckedTextView
+                    android:id="@+id/edit_sync_task_option_ctv_sync_use_remote_small_io_area"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                    android:gravity="center_vertical"
+                    android:text="@string/msgs_profile_sync_task_sync_use_small_ioarea"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                <include layout="@layout/divider_line1" />
+            </LinearLayout>
+            <LinearLayout
+                android:id="@+id/edit_sync_task_option_ll_spinner_wifi_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:orientation="vertical" >
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/msgs_profile_sync_task_sync_option_spinner_wifi_title"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+            </LinearLayout>
             <Spinner
                 android:id="@+id/edit_sync_task_option_spinner_wifi_status"
                 style="?android:attr/spinnerStyle"
@@ -180,11 +224,12 @@
                     android:text="@string/msgs_profile_sync_task_sync_option_ap_list_task_skip_if_ssid_invalid"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
             </LinearLayout>
+            <include layout="@layout/divider_line1" />
             <CheckedTextView
                 android:id="@+id/edit_sync_task_option_sync_allow_global_ip_address"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="10dp"
+                android:layout_marginLeft="20dp"
                 android:checkMark="?android:attr/listChoiceIndicatorMultiple"
                 android:gravity="center_vertical"
                 android:text="@string/msgs_profile_sync_task_sync_option_sync_allow_global_ip_address"
@@ -290,22 +335,6 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/edit_sync_task_option_ll_retry_if_error_occured"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-                <CheckedTextView
-                    android:id="@+id/edit_sync_task_option_ctv_retry_if_error_occured"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
-                    android:gravity="center_vertical"
-                    android:text="@string/msgs_profile_sync_task_sync_option_retry_if_error_occured"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-                <include layout="@layout/divider_line1" />
-            </LinearLayout>
-
-            <LinearLayout
                 android:id="@+id/edit_sync_task_option_ll_sync_use_extended_filter1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -365,22 +394,6 @@
                     android:checkMark="?android:attr/listChoiceIndicatorMultiple"
                     android:gravity="center_vertical"
                     android:text="@string/msgs_profile_sync_task_sync_option_last_modified_smbsync"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-                <include layout="@layout/divider_line1" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/edit_sync_task_option_ll_sync_use_remote_small_io_area"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-                <CheckedTextView
-                    android:id="@+id/edit_sync_task_option_ctv_sync_use_remote_small_io_area"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
-                    android:gravity="center_vertical"
-                    android:text="@string/msgs_profile_sync_task_sync_use_small_ioarea"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
                 <include layout="@layout/divider_line1" />
             </LinearLayout>

--- a/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values-ja/ja_2018_11_26.xml
@@ -419,7 +419,8 @@
         <string name="msgs_profile_sync_task_sync_option_sync_when_charging">充電中の時だけ同期を開始する</string>
         <string name="msgs_profile_sync_task_sync_option_test_mode">テストモード（ファイルのコピーや削除は行われません）</string>
         <string name="msgs_profile_sync_task_sync_option_use_extended_filter1">拡張されたディレクトリ選択/除外フィルタを使用する</string>
-        <string name="msgs_profile_sync_task_sync_option_wifi_condition_title">ネットワークオプション</string>
+        <string name="msgs_profile_sync_task_sync_option_wifi_condition_title">ネットワークオプション:</string>
+        <string name="msgs_profile_sync_task_sync_option_spinner_wifi_title">ワイヤレスAPオプション:</string>
         <string name="msgs_profile_sync_task_sync_option_do_mot_use_rename_when_smb_file_write">SMBフォルダーへのファイル書き込みで一時ファイルを使用せず直接書き込む</string>
         <string name="msgs_profile_sync_task_sync_sub_directory_dir_filter_not_specified">ディレクトリーフィルタが指定されていません</string>
         <string name="msgs_profile_sync_task_option_remove_directory_if_empty_when_move">(同期方式が移動のみ)マスターディレクトリーが空の時にマスターディレクトリーを削除する。</string>

--- a/SMBSync2/src/main/res/values/en_2018_11_26.xml
+++ b/SMBSync2/src/main/res/values/en_2018_11_26.xml
@@ -421,7 +421,8 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_profile_sync_task_sync_option_sync_when_charging">Execute sync tasks only when charging</string>
         <string name="msgs_profile_sync_task_sync_option_test_mode">Test mode (do not copy or delete files)</string>
         <string name="msgs_profile_sync_task_sync_option_use_extended_filter1">Use enhanced directory selection filter</string>
-        <string name="msgs_profile_sync_task_sync_option_wifi_condition_title">Network Option</string>
+        <string name="msgs_profile_sync_task_sync_option_wifi_condition_title">Network Options:</string>
+        <string name="msgs_profile_sync_task_sync_option_spinner_wifi_title">Wifi AP Options:</string>
         <string name="msgs_profile_sync_task_sync_option_do_mot_use_rename_when_smb_file_write">Write files directly to the SMB folder without using temporary files</string>
         <string name="msgs_profile_sync_task_sync_sub_directory_dir_filter_not_specified">Directory filter has not been specified.</string>
         <string name="msgs_profile_sync_task_option_remove_directory_if_empty_when_move">(Sync type only moves) Delete the master directory when the master directory is empty.</string>


### PR DESCRIPTION
- Hide "SMBSync2_2.28.13_259_code-fix-network-options-view" option if neither target nor master are not SMB shares
- Hide "Retry on network error" option if neither target nor master are not SMB shares
- Group network options together