### PR TITLE
Group and hide unused menu items, fix dialg title...

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -2837,7 +2837,7 @@ public class SyncTaskEditor extends DialogFragment {
         final CustomSpinnerAdapter adapter = new CustomSpinnerAdapter(mContext, android.R.layout.simple_spinner_item);
         mGp.safMgr.loadSafFile();
         adapter.setDropDownViewResource(android.R.layout.select_dialog_singlechoice);
-        spinner.setPrompt(mContext.getString(R.string.msgs_main_sync_profile_dlg_sync_folder_type_prompt));
+        spinner.setPrompt(mContext.getString(R.string.msgs_profile_edit_sync_folder_dlg_local_mount_point ));
         spinner.setAdapter(adapter);
 
         int sel_no = 0;
@@ -3315,14 +3315,11 @@ public class SyncTaskEditor extends DialogFragment {
         ctv_edit_sync_task_option_ignore_unusable_character_used_directory_file_name.setChecked(n_sti.isSyncOptionIgnoreDirectoriesOrFilesThatContainUnusableCharacters());
         setCtvListenerForEditSyncTask(ctv_edit_sync_task_option_ignore_unusable_character_used_directory_file_name, type, n_sti, dlg_msg);
 
-        final CheckedTextView ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_do_mot_use_rename_when_smb_file_write);
-        ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write.setChecked(n_sti.isSyncOptionDoNotUseRenameWhenSmbFileWrite());
-        setCtvListenerForEditSyncTask(ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write, type, n_sti, dlg_msg);
-
         final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
         ctv_sync_remove_master_if_empty.setChecked(n_sti.isSyncOptionMoveOnlyRemoveMasterDirectoryIfEmpty());
         setCtvListenerForEditSyncTask(ctv_sync_remove_master_if_empty, type, n_sti, dlg_msg);
 
+        final LinearLayout ll_advanced_network_option_view = (LinearLayout) mDialog.findViewById(R.id.edit_sync_task_option_ll_advanced_network_option_view);
         final CheckedTextView ctvRetry = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_retry_if_error_occured);
         CommonUtilities.setCheckedTextView(ctvRetry);
         if (n_sti.getSyncOptionRetryCount().equals("0")) ctvRetry.setChecked(false);
@@ -3334,10 +3331,15 @@ public class SyncTaskEditor extends DialogFragment {
         ctvSyncUseRemoteSmallIoArea.setChecked(n_sti.isSyncOptionUseSmallIoBuffer());
         setCtvListenerForEditSyncTask(ctvSyncUseRemoteSmallIoArea, type, n_sti, dlg_msg);
 
+        final CheckedTextView ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_do_mot_use_rename_when_smb_file_write);
+        ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write.setChecked(n_sti.isSyncOptionDoNotUseRenameWhenSmbFileWrite());
+        setCtvListenerForEditSyncTask(ctv_edit_sync_tak_option_do_not_use_rename_when_smb_file_write, type, n_sti, dlg_msg);
+
         final Spinner spinnerSyncWifiStatus = (Spinner) mDialog.findViewById(R.id.edit_sync_task_option_spinner_wifi_status);
         setSpinnerSyncTaskWifiOption(spinnerSyncWifiStatus, n_sti.getSyncOptionWifiStatusOption());
         if (n_sti.getMasterFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB) || n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB)) {
-            ll_wifi_condition_view.setVisibility(Button.VISIBLE);
+            ll_wifi_condition_view.setVisibility(LinearLayout.VISIBLE);
+            ll_advanced_network_option_view.setVisibility(LinearLayout.VISIBLE);
             if (n_sti.getSyncOptionWifiStatusOption().equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_CONNECT_SPECIFIC_AP)) {
                 ll_wifi_wl_view.setVisibility(Button.VISIBLE);
                 ll_wifi_wl_ap_view.setVisibility(Button.VISIBLE);
@@ -3346,7 +3348,8 @@ public class SyncTaskEditor extends DialogFragment {
                 ll_wifi_wl_ap_view.setVisibility(Button.GONE);
             }
         } else {
-            ll_wifi_condition_view.setVisibility(Button.GONE);
+            ll_wifi_condition_view.setVisibility(LinearLayout.GONE);
+            ll_advanced_network_option_view.setVisibility(LinearLayout.GONE);
         }
 
         spinnerSyncWifiStatus.setOnItemSelectedListener(new OnItemSelectedListener() {
@@ -3763,9 +3766,11 @@ public class SyncTaskEditor extends DialogFragment {
                         checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
                         if (!prev_master_folder_type.equals(n_sti.getMasterFolderType())) {
                             ll_wifi_condition_view.setVisibility(LinearLayout.VISIBLE);
+                            ll_advanced_network_option_view.setVisibility(LinearLayout.VISIBLE);
                             if ((!n_sti.getMasterFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB) &&
                                     !n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB))) {
                                 ll_wifi_condition_view.setVisibility(LinearLayout.GONE);
+                                ll_advanced_network_option_view.setVisibility(LinearLayout.GONE);
                             } else if (n_sti.getMasterFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB) ||
                                     n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB)) {
                                 if (n_sti.getSyncOptionWifiStatusOption().equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF)) {
@@ -3922,9 +3927,11 @@ public class SyncTaskEditor extends DialogFragment {
 
                         if (!prev_target_folder_type.equals(n_sti.getTargetFolderType())) {
                             ll_wifi_condition_view.setVisibility(LinearLayout.VISIBLE);
+                            ll_advanced_network_option_view.setVisibility(LinearLayout.VISIBLE);
                             if (!n_sti.getMasterFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB) &&
                                     !n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB)) {
                                 ll_wifi_condition_view.setVisibility(LinearLayout.GONE);
+                                ll_advanced_network_option_view.setVisibility(LinearLayout.GONE);
                             } else if (n_sti.getMasterFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB) ||
                                     n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB)) {
                                 if (n_sti.getSyncOptionWifiStatusOption().equals(SyncTaskItem.SYNC_WIFI_STATUS_WIFI_OFF)) {
@@ -4567,6 +4574,7 @@ public class SyncTaskEditor extends DialogFragment {
         final CheckedTextView ctvDiffUseFileSize = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_diff_use_file_size);
 
         final CheckedTextView ctv_sync_remove_master_if_empty = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_remove_directory_if_empty_when_move);
+        final CheckedTextView ctvDeleteFirst = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_delete_first_when_mirror);
 
         final LinearLayout ll_edit_sync_tak_option_keep_conflict_file=(LinearLayout)mDialog.findViewById(R.id.edit_sync_task_option_twoway_sync_keep_conflic_file_view);
         final LinearLayout ll_spinnerTwoWaySyncConflictRule=(LinearLayout)mDialog.findViewById(R.id.edit_sync_task_option_twoway_sync_conflict_file_rule_view);
@@ -4586,6 +4594,9 @@ public class SyncTaskEditor extends DialogFragment {
             ll_sync_remove_master_if_empty.setVisibility(CheckedTextView.GONE);
             ctv_sync_remove_master_if_empty.setChecked(false);
         }
+
+        if (n_sti.getSyncTaskType().equals(SyncTaskItem.SYNC_TASK_TYPE_MIRROR)) ctvDeleteFirst.setVisibility(CheckedTextView.VISIBLE);
+        else ctvDeleteFirst.setVisibility(CheckedTextView.GONE);
 
         if (!n_sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_INTERNAL)) {
             ll_ctvUseSmbsyncLastMod.setVisibility(LinearLayout.GONE);

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
@@ -185,12 +185,13 @@ class SyncTaskItem implements Serializable, Cloneable {
 
     private boolean syncOptionDeterminChangedFileBySize = true;
     private boolean syncOptionDeterminChangedFileByTime = true;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0=1;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1=3;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2=10;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT=SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0;
-    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_LIST_DEFAULT_ITEM_INDEX = 0;
-    public final static int[] SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_LIST =new int[]{SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2};
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0=0;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1=1;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2=3;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_3=5;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT=SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1;
+    public final static int SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_LIST_DEFAULT_ITEM_INDEX = 1;
+    public final static int[] SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_LIST =new int[]{SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_0, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_1, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_2, SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_3};
     private int syncOptionDeterminChangedFileByTimeValue = SYNC_FILE_DIFFERENCE_ALLOWABLE_TIME_DEFAULT;//Seconds
 
     private boolean syncOptionDoNotUseRenameWhenSmbFileWrite = false;

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg_options.xml
@@ -334,34 +334,62 @@
                 <include layout="@layout/divider_line1" />
             </LinearLayout>
             <LinearLayout
-                android:id="@+id/edit_sync_task_option_ll_retry_if_error_occured"
+                android:id="@+id/edit_sync_task_option_ll_advanced_network_option_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
-                <CheckedTextView
-                    android:id="@+id/edit_sync_task_option_ctv_retry_if_error_occured"
-                    android:layout_width="fill_parent"
+                <TextView
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
-                    android:gravity="center_vertical"
-                    android:text="@string/msgs_profile_sync_task_sync_option_retry_if_error_occured"
+                    android:layout_gravity="center_vertical"
+                    android:text="@string/msgs_profile_sync_task_sync_option_network_adv_options"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
-                <include layout="@layout/divider_line1" />
-            </LinearLayout>
-            <LinearLayout
-                android:id="@+id/edit_sync_task_option_ll_sync_use_remote_small_io_area"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-                <CheckedTextView
-                    android:id="@+id/edit_sync_task_option_ctv_sync_use_remote_small_io_area"
-                    android:layout_width="fill_parent"
+                <LinearLayout
+                    android:id="@+id/edit_sync_task_option_ll_retry_if_error_occured"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
-                    android:gravity="center_vertical"
-                    android:text="@string/msgs_profile_sync_task_sync_use_small_ioarea"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-                <include layout="@layout/divider_line1" />
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
+                    <CheckedTextView
+                        android:id="@+id/edit_sync_task_option_ctv_retry_if_error_occured"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                        android:gravity="center_vertical"
+                        android:text="@string/msgs_profile_sync_task_sync_option_retry_if_error_occured"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/edit_sync_task_option_ll_sync_use_remote_small_io_area"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
+                    <CheckedTextView
+                        android:id="@+id/edit_sync_task_option_ctv_sync_use_remote_small_io_area"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                        android:gravity="center_vertical"
+                        android:text="@string/msgs_profile_sync_task_sync_use_small_ioarea"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                </LinearLayout>
+                <LinearLayout
+                    android:id="@+id/edit_sync_task_option_do_mot_use_rename_when_smb_file_write_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="10dp"
+                    android:orientation="vertical">
+                    <CheckedTextView
+                        android:id="@+id/edit_sync_task_option_do_mot_use_rename_when_smb_file_write"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                        android:gravity="center_vertical"
+                        android:text="@string/msgs_profile_sync_task_sync_option_do_mot_use_rename_when_smb_file_write"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+                    <include layout="@layout/divider_line1" />
+                </LinearLayout>
             </LinearLayout>
             <LinearLayout
                 android:id="@+id/edit_sync_task_option_ll_do_mot_reset_file_last_mod_time"
@@ -536,22 +564,6 @@
                     android:checkMark="?android:attr/listChoiceIndicatorMultiple"
                     android:gravity="center_vertical"
                     android:text="@string/msgs_profile_sync_task_sync_option_ignore_unusable_character_used_directory_file_name"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-                <include layout="@layout/divider_line1" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/edit_sync_task_option_do_mot_use_rename_when_smb_file_write_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-                <CheckedTextView
-                    android:id="@+id/edit_sync_task_option_do_mot_use_rename_when_smb_file_write"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:checkMark="?android:attr/listChoiceIndicatorMultiple"
-                    android:gravity="center_vertical"
-                    android:text="@string/msgs_profile_sync_task_sync_option_do_mot_use_rename_when_smb_file_write"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
                 <include layout="@layout/divider_line1" />
             </LinearLayout>

--- a/SMBSync2/src/main/res/values/en_string_resource.xml
+++ b/SMBSync2/src/main/res/values/en_string_resource.xml
@@ -398,7 +398,7 @@ If the "Open From" panel is not displayed, tap the menu button in the upper left
         <string name="msgs_profile_sync_task_sync_option_ap_list_task_skip_if_ssid_invalid">Skip task if the WLAN is not connected to the specified access point, or if WLAN IP does not match the specified IP address.</string>
         <string name="msgs_profile_sync_task_sync_option_sync_allow_global_ip_address">Allow sync with all IP addresses (include public)</string>
         <string name="msgs_profile_sync_task_sync_option_confirm_required">Confirm before overwrite/delete</string>
-        <string name="msgs_profile_sync_task_sync_option_delete_first_when_mirror">Delete files prior to sync (available in Mirror mode)</string>
+        <string name="msgs_profile_sync_task_sync_option_delete_first_when_mirror">Delete files prior to sync (Mirror mode only)</string>
         <string name="msgs_profile_sync_task_sync_option_diff_file_size_greater_than_target">Files are considered different only if size of the source is larger than the destination (Size only compare, disables time difference).</string>
         <string name="msgs_profile_sync_task_sync_option_diff_file_use_file_size">Use file size to determine if files are different</string>
         <string name="msgs_profile_sync_task_sync_option_diff_file_use_last_mod_time">Use time of last modification to determine if files are different</string>


### PR DESCRIPTION
- when editing sync task target/master folder, display the proper "Select mount point" dialog title instead of Folder type title
- hide "Delete files prior to sync (Mirror mode only)" option if sync type is not Mirror
- If neither Target nor Master are SMB shares:
  + hide "Write files directly to the SMB folder without using temp file names"
  + hide "Limit SMB I/O write buffer to 16 KB"
  + hide "Retry on network error" options
- group advnaced options that depend on target/master being SMB