### PR TITLE
Options changed when screen was rotated in task editor

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -467,7 +467,7 @@ public class SyncTaskEditor extends DialogFragment {
                         CommonDialog.setViewEnabled(getActivity(), spinnerSyncOption, true);
                         CommonDialog.setViewEnabled(getActivity(), spinnerSyncWifiStatus, true);
                         CommonDialog.setViewEnabled(getActivity(), spinnerSyncDiffTimeValue, true);
-                        mDisableSpinnerSelected=true;
+                        mDisableSpinnerSelected=false;
                     }
                 }, 500);
             }


### PR DESCRIPTION
- previously, after rotating and back to first position, any further spinner change won't enable Ok button. But checkboxes do enable it.
This patch makes Ok button enabled again if we modify spinners after rotation


**More issues not fixed**
- some checkboxes are reset after rotation (overwrite destination, sync when charging, select subdirectories), others are not
- some spinners are reset to default, others not (time_diff_offset is not reset while dst_offset is reset)

Behaviour is very inconsistent and a better fix avoiding spinners and checkboxes modifications would be better