### PR TITLE
File and Folder filters readability improvements

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -97,6 +97,7 @@ import static com.sentaroh.android.SMBSync2.Constants.APP_SPECIFIC_DIRECTORY;
 import static com.sentaroh.android.SMBSync2.Constants.ARCHIVE_FILE_TYPE;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_PROF_DECRYPT_FAILED;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_PROF_ENCRYPT_FAILED;
+import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_PROF_FILTER_INCLUDE;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_REPLACEABLE_KEYWORD_DAY;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_REPLACEABLE_KEYWORD_DAY_OF_YEAR;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_REPLACEABLE_KEYWORD_MONTH;
@@ -3388,8 +3389,11 @@ public class SyncTaskEditor extends DialogFragment {
         if (filter_list != null && filter_list.size() > 0) {
             String t_info = "", cn = "";
             for (int i = 0; i < filter_list.size(); i++) {
-                t_info += cn + filter_list.get(i).substring(1, filter_list.get(i).length());
-                cn = ",";
+                String inc = filter_list.get(i).substring(0, 1);
+                String filter = filter_list.get(i).substring(1, filter_list.get(i).length());
+                if (inc.equals(SMBSYNC2_PROF_FILTER_INCLUDE)) cn = "(+)";
+                else cn = "(-)";
+                t_info += cn + filter_list.get(i).substring(1, filter_list.get(i).length()) + ";";
             }
             if (!t_info.equals("")) info = t_info;
 //				info=mContext.getString(R.string.msgs_filter_list_dlg_filter_hint)+" : "+t_info;

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3391,8 +3391,8 @@ public class SyncTaskEditor extends DialogFragment {
             for (int i = 0; i < filter_list.size(); i++) {
                 String inc = filter_list.get(i).substring(0, 1);
                 String filter = filter_list.get(i).substring(1, filter_list.get(i).length());
-                if (inc.equals(SMBSYNC2_PROF_FILTER_INCLUDE)) cn = "(+)";
-                else cn = "(-)";
+                if (inc.equals(SMBSYNC2_PROF_FILTER_INCLUDE)) cn = "\u2295"; //(+) ASCII
+                else cn = "\u2296"; //(-) ASCII
                 t_info += cn + filter_list.get(i).substring(1, filter_list.get(i).length()) + ";";
             }
             if (!t_info.equals("")) info = t_info;

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg_filter.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg_filter.xml
@@ -76,7 +76,6 @@
 	            android:layout_height="wrap_content"
 	            android:ellipsize="end"
 	            android:gravity="center_vertical|left"
-	            android:lines="1"
 	            android:hint="@string/msgs_profile_sync_task_dlg_file_filter_not_specified"
 	            android:textAppearance="?android:attr/textAppearanceMedium" />
 	        	        
@@ -102,10 +101,9 @@
 	    	    
 	    <Button
 	        android:id="@+id/sync_filter_edit_dir_filter_btn"
-	        android:layout_width="fill_parent"
+	        android:layout_width="match_parent"
 	        android:layout_height="wrap_content"
 	        android:gravity="center_vertical|left"
-	        android:lines="1"
 	        android:ellipsize="end"
 	        android:hint="@string/msgs_profile_sync_task_dlg_dir_filter_not_specified"
 	        android:textAppearance="?android:attr/textAppearanceMedium" />


### PR DESCRIPTION
Improve readability of the filters in main SyncTask edit dialog:
- wraps button text in multiple lines
- use the ASCII symbols to differentiate include/exclude filters
 - use ";" separator for more standard formatting and readability