### PR TITLE
Exclude filter

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -3324,6 +3324,12 @@ public class SyncTaskUtil {
                 TextView dlg_msg = (TextView) dialog.findViewById(R.id.filter_edit_dlg_msg);
 
                 String newfilter = et_filter.getText().toString();
+                if (newfilter.length() == 0) {
+                    //String mtxt = mContext.getString(R.string.msgs_filter_list_invalid_filter_specified);
+                    String mtxt = "Specified filter is invalid"; // to translate entry fr_msg: "Le filtre spécifié n\'est pas valide"
+                    dlg_msg.setText(String.format(mtxt, newfilter));
+                    return;
+                }
                 if (!filter.equalsIgnoreCase(newfilter)) {
                     if (isFilterExists(newfilter, fa)) {
                         String mtxt = mContext.getString(R.string.msgs_filter_list_duplicate_filter_specified);


### PR DESCRIPTION
- bug: when you enter a filter file/folder/wifiAP and you save it. If you edit the created filter, you were able to save an empty filter

- dir exclude filter support:
  + "\*/cache/\*" matches "/master/cache" or "/master/test/cache" (any /cache/ folder)
  + "/cache/"=="cache/" matches "/master/cache/" (in root of master only)

- file exclude: previously excludes all specified file names
  + support select specific file by path: /master/path/to/file/filename
  + /filename matches filename only in root
  + "\*/filename" == "filename" matches filename anywhere
  + "/te\*/ca\*/New\*" matches specific path up to file New\*, excluding New\* named folders