### PR TITLE
Patch fix ignore count 2

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -2207,6 +2207,7 @@ public class SyncThread extends Thread {
         }
         stwa.util.addDebugMsg(2, "I", "sendConfirmRequest result=" + result, ", rc=" + rc);
 
+        if (!result) stwa.totalIgnoreCount++;//if delete/overwrite cancelled by user, increment ignore count displayed at end of sync messages
         return result;
     }
 
@@ -2259,6 +2260,7 @@ public class SyncThread extends Thread {
         }
         stwa.util.addDebugMsg(2, "I", "sendArchiveConfirmRequest result=" + result, ", rc=" + rc);
 
+        if (!result) stwa.totalIgnoreCount++;//if cancel archive cancelled by user, increment ignore count displayed at end of sync messages
         return result;
     }
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadArchiveFile.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadArchiveFile.java
@@ -95,7 +95,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -114,7 +113,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -276,7 +274,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -334,7 +331,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -352,7 +348,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -492,7 +487,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;//Archive cancelled
@@ -706,7 +700,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -749,7 +742,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -767,7 +759,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -924,7 +915,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -978,7 +968,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -996,7 +985,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -1171,7 +1159,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -1190,7 +1177,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -1389,7 +1375,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -1408,7 +1393,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -1613,7 +1597,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -1683,7 +1666,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -1702,7 +1684,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;
@@ -1893,7 +1874,6 @@ public class SyncThreadArchiveFile {
                 }
             }
         } else {
-            stwa.totalIgnoreCount++;
             SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", to_path, mf.getName(),
                     "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
         }
@@ -1912,7 +1892,6 @@ public class SyncThreadArchiveFile {
             }
             if (!item.date_from_exif && sti.isSyncOptionConfirmNotExistsExifDate()) {
                 if (!SyncThread.sendArchiveConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_ARCHIVE_DATE_FROM_FILE, item.full_path)) {
-                    stwa.totalIgnoreCount++;
                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", item.full_path, item.file_name,
                             "", stwa.context.getString(R.string.msgs_mirror_confirm_archive_date_time_from_file_cancel));
                     continue;

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
@@ -687,8 +687,8 @@ public class SyncThreadSyncFile {
                                                         "", stwa.msgs_mirror_task_file_moved);
                                             }
                                         } else {
-                                                SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", parsed_to_path, mf.getName(),
-                                                        "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
+                                            SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", parsed_to_path, mf.getName(),
+                                                    "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
                                         }
                                     } else {
                                         if (SyncThread.isFileChanged(stwa, sti, parsed_to_path, tf, mf, stwa.ALL_COPY) &&

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncZip.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncZip.java
@@ -625,7 +625,6 @@ public class SyncThreadSyncZip {
                                                 "", stwa.msgs_mirror_task_file_moved);
                                     }
                                 } else {
-                                    stwa.totalIgnoreCount++;
                                     SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", t_from_path, mf.getName(),
                                             "", stwa.context.getString(R.string.msgs_mirror_confirm_move_cancel));
                                 }
@@ -640,7 +639,6 @@ public class SyncThreadSyncZip {
                                             stwa.totalCopyCount++;
                                         }
                                     } else {
-                                        stwa.totalIgnoreCount++;
                                         SyncThread.showMsg(stwa, true, sti.getSyncTaskName(), "I", t_from_path, mf.getName(),
                                                 "", stwa.context.getString(R.string.msgs_mirror_confirm_copy_cancel));
                                     }
@@ -702,7 +700,6 @@ public class SyncThreadSyncZip {
                                     stwa.totalDeleteCount++;
                                     break;
                                 } else {
-                                    stwa.totalIgnoreCount++;
                                     SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", zfli.getPath(), zfli.getFileName(),
                                             "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                                 }


### PR DESCRIPTION
The last partial merge of my ignore_count commit caused ignore count still incremented in user Cancelled Archive/ZIP operations while it was not for other sync operations.

- commit1: revert all increments for Cancelled operations include ZIP and Archive: consistency of the results between ZIP, Archive and Copy/Move/Mirror modes
- commit2: reapply it properly and globally if wanted in the "send confirm request" methods