### PR TITLE
Fix include filter error

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThread.java
@@ -3365,7 +3365,7 @@ public class SyncThread extends Thread {
                         else pre_str = "";
 
                         //include filter==dir -> only include dir/* but not dir2/*
-                        if (!filter_item.endsWith("/")) suf_str = "$";
+                        if (!filter_item.endsWith("/")) suf_str = "/";
                         else suf_str = "";
 
                         dfinc = pre_str + MiscUtil.convertRegExp(filter_item) + suf_str;


### PR DESCRIPTION
Fix mistype error in last commit "Fix empty excluded folders always created" https://github.com/Sentaroh/SMBSync2/pull/117/commits/0753895b909d6c2ef9553fd95bb84275b929deef causing files inside included folders were no more included