### PR TITLE
bug fix: unexpected file and directories deletes in Mirror:

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
@@ -127,19 +127,16 @@ public class SyncThreadSyncFile {
 //				String parent_dir="", t_dir=tmp_target_dir.length()>0?tmp_target_dir.substring(1):"";
 //				if (t_dir.lastIndexOf("/")>=0) parent_dir="/"+t_dir.substring(0, t_dir.lastIndexOf("/"));
 //				Log.v("","parent="+parent_dir+", t="+t_dir+", tmp="+tmp_target_dir);
-                if (//!SyncThread.isDirectoryExcluded(stwa, parent_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
-                    if (!SyncThread.isHiddenFile(stwa, sti, tf)) {
-                        if (!isSmbFileExists(stwa, smb_fl, master_dir)) {
-                            if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
-                                if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
-                                    SyncThread.deleteExternalStorageItem(stwa, true, sti, target_dir);
-                                } else {
-                                    stwa.totalIgnoreCount++;
-                                    SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                                            "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
-                                }
+                if (!SyncThread.isHiddenFile(stwa, sti, tf) && SyncThread.isDirectorySelectedByFileName(stwa, tmp_target_dir) && SyncThread.isFileSelected(stwa, sti, tmp_target_dir)) {
+                    //if (stwa.gp.settingDebugLevel >= 2) stwa.util.addDebugMsg(2, "I", "syncDeleteSmbToExternal: " + "tmp_target_dir="+tmp_target_dir + ", tf="+tf + ", master_dir="+master_dir + ", target_dir="+target_dir);
+                    if (!isSmbFileExists(stwa, smb_fl, master_dir)) {
+                        if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
+                            if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
+                                SyncThread.deleteExternalStorageItem(stwa, true, sti, target_dir);
+                            } else {
+                                stwa.totalIgnoreCount++;
+                                SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                        "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                             }
                         }
                     }
@@ -232,19 +229,16 @@ public class SyncThreadSyncFile {
 //				String parent_dir="", t_dir=tmp_target_dir.length()>0?tmp_target_dir.substring(1):"";
 //				if (t_dir.lastIndexOf("/")>=0) parent_dir="/"+t_dir.substring(0, t_dir.lastIndexOf("/"));
 //				Log.v("","parent="+parent_dir+", t="+t_dir+", tmp="+tmp_target_dir);
-                if (//!SyncThread.isDirectoryExcluded(stwa, parent_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
-                    if (!SyncThread.isHiddenFile(stwa, sti, tf)) {
-                        if (!isSmbFileExists(stwa, smb_fl, master_dir)) {
-                            if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
-                                if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
-                                    SyncThread.deleteInternalStorageItem(stwa, true, sti, target_dir);
-                                } else {
-                                    stwa.totalIgnoreCount++;
-                                    SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                                            "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
-                                }
+                if (!SyncThread.isHiddenFile(stwa, sti, tf) && SyncThread.isDirectorySelectedByFileName(stwa, tmp_target_dir) && SyncThread.isFileSelected(stwa, sti, tmp_target_dir)) {
+                    //if (stwa.gp.settingDebugLevel >= 2) stwa.util.addDebugMsg(2, "I", "syncDeleteSmbToInternal: " + "tmp_target_dir="+tmp_target_dir + ", tf="+tf + ", master_dir="+master_dir + ", target_dir="+target_dir);
+                    if (!isSmbFileExists(stwa, smb_fl, master_dir)) {
+                        if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
+                            if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
+                                SyncThread.deleteInternalStorageItem(stwa, true, sti, target_dir);
+                            } else {
+                                stwa.totalIgnoreCount++;
+                                SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                        "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                             }
                         }
                     }
@@ -327,21 +321,17 @@ public class SyncThreadSyncFile {
 //			String parent_dir="", t_dir=tmp_target_dir.length()>0?tmp_target_dir.substring(1):"";
 //			if (t_dir.lastIndexOf("/")>=0) parent_dir="/"+t_dir.substring(0, t_dir.lastIndexOf("/"));
 //			Log.v("","parent="+parent_dir+", t="+t_dir+", tmp="+tmp_target_dir);
-            if (//!SyncThread.isDirectoryExcluded(stwa, parent_dir) &&
-                    !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                            SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)
-                    ) {
-                if (!SyncThread.isHiddenFile(stwa, sti, tf)) {
-                    mf = new File(master_dir);
-                    if (!mf.exists()) {
-                        if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
-                            if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
-                                SyncThread.deleteInternalStorageItem(stwa, true, sti, target_dir);
-                            } else {
-                                stwa.totalIgnoreCount++;
-                                SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                                       "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
-                            }
+            if (!SyncThread.isHiddenFile(stwa, sti, tf) && SyncThread.isDirectorySelectedByFileName(stwa, tmp_target_dir) && SyncThread.isFileSelected(stwa, sti, tmp_target_dir)) {
+                //if (stwa.gp.settingDebugLevel >= 2) stwa.util.addDebugMsg(2, "I", "syncDeleteInternalToInternal: " + "tmp_target_dir="+tmp_target_dir + ", tf="+tf + ", master_dir="+master_dir + ", target_dir="+target_dir);
+                mf = new File(master_dir);
+                if (!mf.exists()) {
+                    if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
+                        if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
+                            SyncThread.deleteInternalStorageItem(stwa, true, sti, target_dir);
+                        } else {
+                            stwa.totalIgnoreCount++;
+                            SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                   "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                         }
                     }
                 }
@@ -431,21 +421,17 @@ public class SyncThreadSyncFile {
 //				String parent_dir="", t_dir=tmp_target_dir.length()>0?tmp_target_dir.substring(1):"";
 //				if (t_dir.lastIndexOf("/")>=0) parent_dir="/"+t_dir.substring(0, t_dir.lastIndexOf("/"));
 //				Log.v("","parent="+parent_dir+", t="+t_dir+", tmp="+tmp_target_dir);
-                if (//!SyncThread.isDirectoryExcluded(stwa, parent_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)
-                ) {
-                    if (!SyncThread.isHiddenFile(stwa, sti, tf)) {
-                        mf = new File(master_dir);
-                        if (!mf.exists()) {
-                            if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
-                                if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
-                                    SyncThread.deleteSmbItem(stwa, true, sti, to_base, target_dir, stwa.targetAuth);
-                                } else {
-                                    stwa.totalIgnoreCount++;
-                                    SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                                            "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
-                                }
+                if (!SyncThread.isHiddenFile(stwa, sti, tf) && SyncThread.isDirectorySelectedByFileName(stwa, tmp_target_dir) && SyncThread.isFileSelected(stwa, sti, tmp_target_dir)) {
+                    //if (stwa.gp.settingDebugLevel >= 2) stwa.util.addDebugMsg(2, "I", "syncDeleteInternalToSmb: " + "tmp_target_dir="+tmp_target_dir + ", tf="+tf + ", master_dir="+master_dir + ", target_dir="+target_dir);
+                    mf = new File(master_dir);
+                    if (!mf.exists()) {
+                        if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
+                            if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
+                                SyncThread.deleteSmbItem(stwa, true, sti, to_base, target_dir, stwa.targetAuth);
+                            } else {
+                                stwa.totalIgnoreCount++;
+                                SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                        "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                             }
                         }
                     }
@@ -468,6 +454,7 @@ public class SyncThreadSyncFile {
 //				master_dir, target_dir, target_dir, tf);
 //	};
 
+    //called by sync syncMirrorInternalToExternal() and syncMirrorExternalToExternal() at end of copy operation to delete non matching target files
     static final private int syncDeleteInternalToExternal(SyncThreadWorkArea stwa, SyncTaskItem sti, String from_base,
                                                           String master_dir, String to_base, String target_dir, File tf) {
         int sync_result = 0;
@@ -514,18 +501,17 @@ public class SyncThreadSyncFile {
                 }
             }
         } else { // file Delete
-            if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
-                if (!SyncThread.isHiddenFile(stwa, sti, tf)) {
-                    mf = new File(master_dir);
-                    if (!mf.exists()) {
-                        if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
-                            if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
-                                SyncThread.deleteExternalStorageItem(stwa, true, sti, target_dir);
-                            } else {
-                                stwa.totalIgnoreCount++;
-                                SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                                        "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
-                            }
+            if (!SyncThread.isHiddenFile(stwa, sti, tf) && SyncThread.isDirectorySelectedByFileName(stwa, tmp_target_dir) && SyncThread.isFileSelected(stwa, sti, tmp_target_dir)) {
+                //if (stwa.gp.settingDebugLevel >= 2) stwa.util.addDebugMsg(2, "I", "syncDeleteInternalToExternal: " + "tmp_target_dir="+tmp_target_dir + ", tf="+tf + ", master_dir="+master_dir + ", target_dir="+target_dir);
+                mf = new File(master_dir);
+                if (!mf.exists()) {
+                    if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
+                        if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
+                            SyncThread.deleteExternalStorageItem(stwa, true, sti, target_dir);
+                        } else {
+                            stwa.totalIgnoreCount++;
+                            SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                    "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                         }
                     }
                 }
@@ -3010,19 +2996,16 @@ public class SyncThreadSyncFile {
 //				String parent_dir="", t_dir=tmp_target_dir.length()>0?tmp_target_dir.substring(1):"";
 //				if (t_dir.lastIndexOf("/")>=0) parent_dir="/"+t_dir.substring(0, t_dir.lastIndexOf("/"));
 //				Log.v("","parent="+parent_dir+", t="+t_dir+", tmp="+tmp_target_dir);
-                if (//!SyncThread.isDirectoryExcluded(stwa, parent_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
-                    if (!SyncThread.isHiddenFile(stwa, sti, tf)) {
-                        if (!isSmbFileExists(stwa, smb_fl, master_dir)) {
-                            if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
-                                if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
-                                    SyncThread.deleteSmbItem(stwa, true, sti, to_base, target_dir, stwa.targetAuth);
-                                } else {
-                                    stwa.totalIgnoreCount++;
-                                    SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                                            "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
-                                }
+                if (!SyncThread.isHiddenFile(stwa, sti, tf) && SyncThread.isDirectorySelectedByFileName(stwa, tmp_target_dir) && SyncThread.isFileSelected(stwa, sti, tmp_target_dir)) {
+                    //if (stwa.gp.settingDebugLevel >= 2) stwa.util.addDebugMsg(2, "I", "syncDeleteSmbToSmb: " + "tmp_target_dir="+tmp_target_dir + ", tf="+tf + ", master_dir="+master_dir + ", target_dir="+target_dir);
+                    if (!isSmbFileExists(stwa, smb_fl, master_dir)) {
+                        if (!(tmp_target_dir.equals("") && !sti.isSyncProcessRootDirFile())) {
+                            if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_FILE, target_dir)) {
+                                SyncThread.deleteSmbItem(stwa, true, sti, to_base, target_dir, stwa.targetAuth);
+                            } else {
+                                stwa.totalIgnoreCount++;
+                                SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                        "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
                             }
                         }
                     }

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
@@ -71,9 +71,7 @@ public class SyncThreadSyncFile {
             String tmp_target_dir = target_dir.substring(to_base.length());
             if (tmp_target_dir.startsWith("/")) tmp_target_dir = tmp_target_dir.substring(1);
             if (tf.isDirectory()) { // Directory Delete
-                if (//!SyncThread.isDirectoryExcluded(stwa, tmp_target_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
+                if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
                     if (isSmbFileExists(stwa, smb_fl, master_dir)) {
                         File[] children = tf.listFiles();
                         if (children != null) {
@@ -172,9 +170,7 @@ public class SyncThreadSyncFile {
             String tmp_target_dir = target_dir.substring(to_base.length());
             if (tmp_target_dir.startsWith("/")) tmp_target_dir = tmp_target_dir.substring(1);
             if (tf.isDirectory()) { // Directory Delete
-                if (//!SyncThread.isDirectoryExcluded(stwa, tmp_target_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
+                if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
                     if (isSmbFileExists(stwa, smb_fl, master_dir)) {
                         File[] children = tf.listFiles();
                         if (children != null) {
@@ -281,10 +277,7 @@ public class SyncThreadSyncFile {
         String tmp_target_dir = target_dir.substring(to_base.length());
         if (tmp_target_dir.startsWith("/")) tmp_target_dir = tmp_target_dir.substring(1);
         if (tf.isDirectory()) { // Directory Delete
-            if (//!SyncThread.isDirectoryExcluded(stwa, tmp_target_dir) &&
-                    !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                            SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)
-                    ) {
+            if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
                 mf = new File(master_dir);
                 if (mf.exists()) {
                     File[] children = tf.listFiles();
@@ -367,9 +360,7 @@ public class SyncThreadSyncFile {
         if (tmp_target_dir.startsWith("/")) tmp_target_dir = tmp_target_dir.substring(1);
         try {
             if (tf.isDirectory()) { // Directory Delete
-                if (//!SyncThread.isDirectoryExcluded(stwa, tmp_target_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
+                if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
                     mf = new File(master_dir);
                     if (mf.exists()) {
                         JcifsFile[] children = tf.listFiles();
@@ -2937,9 +2928,7 @@ public class SyncThreadSyncFile {
             String tmp_target_dir = target_dir.substring(to_base.length());
             if (tmp_target_dir.startsWith("/")) tmp_target_dir = tmp_target_dir.substring(1);
             if (tf.isDirectory()) { // Directory Delete
-                if (//!SyncThread.isDirectoryExcluded(stwa, tmp_target_dir) &&
-                        !SyncThread.isHiddenDirectory(stwa, sti, tf) &&
-                                SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
+                if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
                     if (isSmbFileExists(stwa, smb_fl, master_dir)) {
                         JcifsFile[] children = tf.listFiles();
                         if (children != null) {

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncThreadSyncFile.java
@@ -465,9 +465,9 @@ public class SyncThreadSyncFile {
         String tmp_target_dir = target_dir.replace(to_base, "");
         if (tmp_target_dir.startsWith("/")) tmp_target_dir = tmp_target_dir.substring(1);
         if (tf.isDirectory()) { // Directory Delete
-            mf = new File(master_dir);
-            if (mf.exists()) {
-                if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
+            if (!SyncThread.isHiddenDirectory(stwa, sti, tf) && SyncThread.isDirectoryToBeProcessed(stwa, tmp_target_dir)) {
+                mf = new File(master_dir);
+                if (mf.exists()) {
                     File[] children = tf.listFiles();
                     if (children != null) {
                         for (File element : children) {
@@ -490,14 +490,14 @@ public class SyncThreadSyncFile {
                         stwa.util.addLogMsg("W", "File/Directory was not found, fp=" + tf.getPath());
 //						sync_result=SyncTaskItem.SYNC_STATUS_ERROR;
                     }
-                }
-            } else {
-                if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_DIR, target_dir)) {
-                    SyncThread.deleteExternalStorageItem(stwa, true, sti, target_dir);
                 } else {
-                    stwa.totalIgnoreCount++;
-                    SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
-                            "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
+                    if (SyncThread.sendConfirmRequest(stwa, sti, SMBSYNC2_CONFIRM_REQUEST_DELETE_DIR, target_dir)) {
+                        SyncThread.deleteExternalStorageItem(stwa, true, sti, target_dir);
+                    } else {
+                        stwa.totalIgnoreCount++;
+                        SyncThread.showMsg(stwa, false, sti.getSyncTaskName(), "I", target_dir, tf.getName(),
+                                "", stwa.context.getString(R.string.msgs_mirror_confirm_delete_cancel));
+                    }
                 }
             }
         } else { // file Delete


### PR DESCRIPTION
If a file on target doesn't match the file filter, unlike folders, if it doesn't exist on source, it is deleted on the target during mirror sync