### PR TITLE
Scroll in long path source/destination views

### DIFF
--- a/SMBSync2/src/main/res/layout-land/edit_sync_task_dlg.xml
+++ b/SMBSync2/src/main/res/layout-land/edit_sync_task_dlg.xml
@@ -161,6 +161,14 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal" >
 
+                <HorizontalScrollView
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:fillViewport="true"
+                    android:scrollbars="none"
+                    android:layout_marginRight="5dp"
+                    android:orientation="horizontal"
+                    android:textAppearance="?android:attr/textAppearanceSmall" >
                     <Button
                         android:id="@+id/edit_sync_task_master_folder_info_btn"
                         android:layout_width="0dp"
@@ -174,6 +182,7 @@
                         android:ellipsize="end"
                         android:maxLines="1"
                         android:textAppearance="?android:attr/textAppearanceMedium" />
+                </HorizontalScrollView>
 
                 </LinearLayout>
 
@@ -190,6 +199,14 @@
                     android:orientation="horizontal"
                     android:textAppearance="?android:attr/textAppearanceSmall" >
 
+                <HorizontalScrollView
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:fillViewport="true"
+                    android:scrollbars="none"
+                    android:layout_marginRight="5dp"
+                    android:orientation="horizontal"
+                    android:textAppearance="?android:attr/textAppearanceSmall" >
                     <Button
                         android:id="@+id/edit_sync_task_target_folder_info_btn"
                         android:layout_width="0dp"
@@ -203,6 +220,7 @@
                         android:maxLines="1"
                         android:text="TextView"
                         android:textAppearance="?android:attr/textAppearanceMedium" />
+                </HorizontalScrollView>
 
                 </LinearLayout>
 

--- a/SMBSync2/src/main/res/layout-large/edit_sync_task_dlg.xml
+++ b/SMBSync2/src/main/res/layout-large/edit_sync_task_dlg.xml
@@ -162,6 +162,14 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal" >
 
+                <HorizontalScrollView
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:fillViewport="true"
+                    android:scrollbars="none"
+                    android:layout_marginRight="5dp"
+                    android:orientation="horizontal"
+                    android:textAppearance="?android:attr/textAppearanceSmall" >
                     <Button
                         android:id="@+id/edit_sync_task_master_folder_info_btn"
                         android:layout_width="0dp"
@@ -175,6 +183,8 @@
                         android:paddingLeft="5dp"
                         android:text="TextView"
                         android:textAppearance="?android:attr/textAppearanceMedium" />
+                </HorizontalScrollView>
+
                 </LinearLayout>
 
                 <TextView
@@ -190,6 +200,14 @@
                     android:orientation="horizontal"
                     android:textAppearance="?android:attr/textAppearanceSmall" >
 
+                <HorizontalScrollView
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:fillViewport="true"
+                    android:scrollbars="none"
+                    android:layout_marginRight="5dp"
+                    android:orientation="horizontal"
+                    android:textAppearance="?android:attr/textAppearanceSmall" >
                     <Button
                         android:id="@+id/edit_sync_task_target_folder_info_btn"
                         android:layout_width="0dp"
@@ -203,6 +221,8 @@
                         android:paddingLeft="5dp"
                         android:text="TextView"
                         android:textAppearance="?android:attr/textAppearanceMedium" />
+                </HorizontalScrollView>
+
                 </LinearLayout>
 
                 <include layout="@layout/edit_sync_task_dlg_filter" />

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg.xml
@@ -161,6 +161,14 @@
                    android:layout_height="wrap_content"
                    android:orientation="horizontal" >
 
+               <HorizontalScrollView
+                   android:layout_width="fill_parent"
+                   android:layout_height="wrap_content"
+                   android:fillViewport="true"
+                   android:scrollbars="none"
+                   android:layout_marginRight="5dp"
+                   android:orientation="horizontal"
+                   android:textAppearance="?android:attr/textAppearanceSmall" >
                    <Button
                        android:id="@+id/edit_sync_task_master_folder_info_btn"
                        android:layout_width="0dp"
@@ -174,6 +182,7 @@
 			           android:ellipsize="end"
 			           android:maxLines="1"
                        android:textAppearance="?android:attr/textAppearanceMedium" />
+               </HorizontalScrollView>
 
                </LinearLayout>
 
@@ -184,12 +193,14 @@
                    android:text="@string/msgs_profile_sync_task_dlg_target"
                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-               <LinearLayout
+               <HorizontalScrollView
                    android:layout_width="fill_parent"
                    android:layout_height="wrap_content"
+                   android:fillViewport="true"
+                   android:scrollbars="none"
+                   android:layout_marginRight="5dp"
                    android:orientation="horizontal"
                    android:textAppearance="?android:attr/textAppearanceSmall" >
-
                    <Button
                        android:id="@+id/edit_sync_task_target_folder_info_btn"
                        android:layout_width="0dp"
@@ -203,8 +214,7 @@
 			           android:maxLines="1"
                        android:text="TextView"
                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-               </LinearLayout>
+               </HorizontalScrollView>
 
                <include layout="@layout/edit_sync_task_dlg_filter" />
 

--- a/SMBSync2/src/main/res/layout/sync_task_item_view.xml
+++ b/SMBSync2/src/main/res/layout/sync_task_item_view.xml
@@ -65,14 +65,24 @@
                             android:layout_gravity="center_vertical|top"
                             android:src="@drawable/ic_16_server" />
 
-                        <TextView
-                            android:id="@+id/sync_task_master_info"
-                            android:layout_width="wrap_content"
+                        <HorizontalScrollView
+                            android:layout_width="fill_parent"
                             android:layout_height="wrap_content"
-                            android:ellipsize="end"
-                            android:lines="1"
-                            android:text="Master"
-                            android:textAppearance="?android:attr/textAppearanceSmall" />
+                            android:fillViewport="true"
+                            android:scrollbars="none"
+                            android:orientation="horizontal"
+                            android:layout_marginRight="5dp"
+                            android:textAppearance="?android:attr/textAppearanceSmall" >
+                            <TextView
+                                android:id="@+id/sync_task_master_info"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:ellipsize="end"
+                                android:lines="1"
+                                android:text="Master"
+                                android:textAppearance="?android:attr/textAppearanceSmall" />
+                        </HorizontalScrollView>
+
                     </LinearLayout>
 
                     <LinearLayout
@@ -95,14 +105,24 @@
                             android:layout_gravity="top"
                             android:src="@drawable/ic_16_server" />
 
-                        <TextView
-                            android:id="@+id/sync_task_target_info"
-                            android:layout_width="wrap_content"
+                        <HorizontalScrollView
+                            android:layout_width="fill_parent"
                             android:layout_height="wrap_content"
-                            android:ellipsize="end"
-                            android:lines="1"
-                            android:text="Target"
-                            android:textAppearance="?android:attr/textAppearanceSmall" />
+                            android:fillViewport="true"
+                            android:scrollbars="none"
+                            android:orientation="horizontal"
+                            android:layout_marginRight="5dp"
+                            android:textAppearance="?android:attr/textAppearanceSmall" >
+                            <TextView
+                                android:id="@+id/sync_task_target_info"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:ellipsize="end"
+                                android:lines="1"
+                                android:text="Target"
+                                android:textAppearance="?android:attr/textAppearanceSmall" />
+                        </HorizontalScrollView>
+
                     </LinearLayout>
                 </LinearLayout>
 


### PR DESCRIPTION
- Enable scrolling to see full source/destination path when they are long names
See comment for the current small layout bugs