### PR TITLE
properly scroll long paths in main view [missing click]

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncTask.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncTask.java
@@ -29,6 +29,7 @@ import android.content.Context;
 import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.text.InputType;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -36,6 +37,7 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -188,8 +190,8 @@ public class AdapterSyncTask extends ArrayAdapter<SyncTaskItem> {
             holder.cbv_row_cb1 = (CheckBox) v.findViewById(R.id.sync_task_selected);
             holder.ib_row_sync=(ImageButton)v.findViewById(R.id.sync_task_perform_sync);
 
-            holder.tv_row_master = (TextView) v.findViewById(R.id.sync_task_master_info);
-            holder.tv_row_target = (TextView) v.findViewById(R.id.sync_task_target_info);
+            holder.tv_row_master = (EditText) v.findViewById(R.id.sync_task_master_info);
+            holder.tv_row_target = (EditText) v.findViewById(R.id.sync_task_target_info);
             holder.tv_row_synctype = (TextView) v.findViewById(R.id.sync_task_sync_type);
             holder.iv_row_sync_dir_image = (ImageView) v.findViewById(R.id.sync_task_direction_image);
             holder.iv_row_image_master = (ImageView) v.findViewById(R.id.sync_task_master_icon);
@@ -327,6 +329,9 @@ public class AdapterSyncTask extends ArrayAdapter<SyncTaskItem> {
                 }
                 holder.iv_row_image_master.setImageResource(R.drawable.ic_32_server);
             }
+            holder.tv_row_master.setTextColor(mTextColor);
+            holder.tv_row_master.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+
             String target_dir = o.getTargetDirectoryName().startsWith("/")?o.getTargetDirectoryName().substring(1):o.getTargetDirectoryName();
             if (o.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_INTERNAL)) {
                 if (target_dir.equals("")) holder.tv_row_target.setText(o.getTargetLocalMountPoint());
@@ -373,6 +378,8 @@ public class AdapterSyncTask extends ArrayAdapter<SyncTaskItem> {
                 }
                 holder.iv_row_image_target.setImageResource(R.drawable.ic_32_server);
             }
+            holder.tv_row_target.setTextColor(mTextColor);
+            holder.tv_row_target.setInputType(InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
 
             if (isShowCheckBox) {
                 holder.cbv_row_cb1.setVisibility(CheckBox.VISIBLE);
@@ -424,7 +431,8 @@ public class AdapterSyncTask extends ArrayAdapter<SyncTaskItem> {
         CheckBox cbv_row_cb1;
         ImageButton ib_row_sync;
 
-        TextView tv_row_synctype, tv_row_master, tv_row_target;
+        TextView tv_row_synctype;
+        EditText tv_row_master, tv_row_target;
         ImageView iv_row_sync_dir_image;
         ImageView iv_row_image_master, iv_row_image_target;
         String tv_mtype_mirror, tv_mtype_move, tv_mtype_copy, tv_mtype_sync, tv_mtype_archive;

--- a/SMBSync2/src/main/res/layout/sync_task_item_view.xml
+++ b/SMBSync2/src/main/res/layout/sync_task_item_view.xml
@@ -65,10 +65,17 @@
                             android:layout_gravity="center_vertical|top"
                             android:src="@drawable/ic_16_server" />
 
-                        <TextView
+                        <EditText
                             android:id="@+id/sync_task_master_info"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:inputType="none"
+                            android:background="@android:color/transparent"
+                            android:cursorVisible="false"
+                            android:clickable="false"
+                            android:focusable="false"
+                            android:focusableInTouchMode="false"
+                            android:singleLine="true"
                             android:ellipsize="end"
                             android:lines="1"
                             android:text="Master"
@@ -95,10 +102,17 @@
                             android:layout_gravity="top"
                             android:src="@drawable/ic_16_server" />
 
-                        <TextView
+                        <EditText
                             android:id="@+id/sync_task_target_info"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:inputType="none"
+                            android:background="@android:color/transparent"
+                            android:cursorVisible="false"
+                            android:clickable="false"
+                            android:focusable="false"
+                            android:focusableInTouchMode="false"
+                            android:singleLine="true"
                             android:ellipsize="end"
                             android:lines="1"
                             android:text="Target"


### PR DESCRIPTION
- long press actions are preserved on all the text field
- swipe tabs action is preserved on all the text field if it is short (not scrollable text)
- swipe tabs action is preserved at end of horizontal scroll of a text long field

Missing: click action to edit sync task when clicked on the path text field