### PR TITLE
Expand long path in main view on item selection + Zip icon fix

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncTask.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterSyncTask.java
@@ -328,6 +328,7 @@ public class AdapterSyncTask extends ArrayAdapter<SyncTaskItem> {
                 holder.iv_row_image_master.setImageResource(R.drawable.ic_32_server);
             }
             holder.tv_row_master.requestLayout();
+
             String target_dir = o.getTargetDirectoryName().startsWith("/")?o.getTargetDirectoryName().substring(1):o.getTargetDirectoryName();
             if (o.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_INTERNAL)) {
                 if (target_dir.equals("")) holder.tv_row_target.setText(o.getTargetLocalMountPoint());
@@ -409,6 +410,8 @@ public class AdapterSyncTask extends ArrayAdapter<SyncTaskItem> {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                     o.setChecked(isChecked);
+                    holder.tv_row_master.setSingleLine(!isChecked);
+                    holder.tv_row_target.setSingleLine(!isChecked);
                     items.set(p, o);
                     if (mNotifyCheckBoxEvent != null && isShowCheckBox)
                         mNotifyCheckBoxEvent.notifyToListener(true, null);

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -2998,7 +2998,7 @@ public class SyncTaskEditor extends DialogFragment {
                     mGp.safMgr.getSdcardRootPath().equals(SafManager.UNKNOWN_SDCARD_DIRECTORY)) {
                 info_icon.setImageDrawable(mContext.getResources().getDrawable(R.drawable.ic_32_sdcard_bad, null));
             } else {
-                info_icon.setImageDrawable(mContext.getResources().getDrawable(R.drawable.ic_32_sdcard, null));
+                info_icon.setImageDrawable(mContext.getResources().getDrawable(R.drawable.ic_32_archive, null));
             }
         } else if (sti.getTargetFolderType().equals(SyncTaskItem.SYNC_FOLDER_TYPE_SMB)) {
             String host = sti.getTargetSmbAddr();

--- a/SMBSync2/src/main/res/layout/sync_task_item_view.xml
+++ b/SMBSync2/src/main/res/layout/sync_task_item_view.xml
@@ -65,11 +65,13 @@
                             android:layout_gravity="center_vertical|top"
                             android:src="@drawable/ic_16_server" />
 
-                        <com.sentaroh.android.Utilities.Widget.NonWordwrapTextView
+                        <TextView
                             android:id="@+id/sync_task_master_info"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
+                            android:ellipsize="middle"
+                            android:singleLine="true"
                             android:text="Master"
                             android:textAppearance="?android:attr/textAppearanceSmall" />
                     </LinearLayout>
@@ -94,11 +96,13 @@
                             android:layout_gravity="top"
                             android:src="@drawable/ic_16_server" />
 
-                        <com.sentaroh.android.Utilities.Widget.NonWordwrapTextView
+                        <TextView
                             android:id="@+id/sync_task_target_info"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_weight="1"
+                            android:ellipsize="middle"
+                            android:singleLine="true"
                             android:text="Target"
                             android:textAppearance="?android:attr/textAppearanceSmall" />
                     </LinearLayout>


### PR DESCRIPTION
- When Sync Task Item is selected, expand the path to display it all
- Fix the Zip icon in Edit Sync task dialog