### PR TITLE
Fix Option cannot be disabled once enabled + hide v1 filter option when v2 filter is selected

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3935,7 +3935,7 @@ public class SyncTaskEditor extends DialogFragment {
 
                     @Override
                     public void negativeResponse(Context context, Object[] objects) {
-                        ctvDoNotResetFileLastMod.setChecked(false);
+                        checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
                     }
                 });
                 if (isChecked) {
@@ -3945,6 +3945,9 @@ public class SyncTaskEditor extends DialogFragment {
                             mContext.getString(R.string.msgs_common_dialog_confirm),
                             mContext.getString(R.string.msgs_common_dialog_cancel),
                             ntfy);
+                } else {
+                    ctvDoNotResetFileLastMod.setChecked(false);
+                    checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
                 }
             }
         });

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -3868,6 +3868,8 @@ public class SyncTaskEditor extends DialogFragment {
         final CheckedTextView ctUseExtendedDirectoryFilter1 = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_use_extended_filter1);
         CommonUtilities.setCheckedTextView(ctUseExtendedDirectoryFilter1);
         ctUseExtendedDirectoryFilter1.setChecked(n_sti.isSyncOptionUseExtendedDirectoryFilter1());
+        if (n_sti.isSyncOptionUseDirectoryFilterV2()) ctUseExtendedDirectoryFilter1.setVisibility(CheckedTextView.GONE);
+        else ctUseExtendedDirectoryFilter1.setVisibility(CheckedTextView.VISIBLE);
         setCtvListenerForEditSyncTask(ctUseExtendedDirectoryFilter1, type, n_sti, dlg_msg);
 
         final CheckedTextView ctUseDirectoryFilterV2 = (CheckedTextView) mDialog.findViewById(R.id.edit_sync_task_option_ctv_sync_use_directory_filter_v2);
@@ -3882,6 +3884,9 @@ public class SyncTaskEditor extends DialogFragment {
                     @Override
                     public void positiveResponse(Context context, Object[] objects) {
                         ctUseDirectoryFilterV2.setChecked(isChecked);
+                        if (isChecked) ctUseExtendedDirectoryFilter1.setVisibility(CheckedTextView.GONE);
+                        else ctUseExtendedDirectoryFilter1.setVisibility(CheckedTextView.VISIBLE);
+
                         checkSyncTaskOkButtonEnabled(mDialog, type, n_sti, dlg_msg);
                     }
                     @Override


### PR DESCRIPTION
fix "Do not set last modified time of destination file to match source file" option cannot be disabled once enabled after the warning dialog,