### PR TITLE
Support generic list separator - beta, missing parts

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ActivityMain.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ActivityMain.java
@@ -4498,7 +4498,7 @@ public class ActivityMain extends AppCompatActivity {
             if (item.isChecked()  && !item.isSyncTaskError()) {
                 t_list.add(item);
                 sync_list_tmp += sep + item.getSyncTaskName();
-                sep = ",";
+                sep = ";";
                 if (item.isSyncTestMode()) test_sync_task_found = true;
             }
         }
@@ -4540,7 +4540,7 @@ public class ActivityMain extends AppCompatActivity {
             if (item.isSyncTaskAuto() && !item.isSyncTestMode() && !item.isSyncTaskError()) {
                 t_list.add(item);
                 sync_list_tmp += sep + item.getSyncTaskName();
-                sep = ",";
+                sep = ";";
             }
         }
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterScheduleList.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/AdapterScheduleList.java
@@ -16,6 +16,9 @@ import com.sentaroh.android.Utilities.NotifyEvent;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.regex.Pattern;
+
+import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_LIST_SEPARATOR;
 
 class AdapterScheduleList extends ArrayAdapter<ScheduleItem> {
     private int layout_id = 0;
@@ -202,14 +205,14 @@ class AdapterScheduleList extends ArrayAdapter<ScheduleItem> {
                 if (o.syncTaskList.equals("")) {
                     schedule_error=true;
                 } else {
-                    if (o.syncTaskList.indexOf(",")>0) {
-                        String[] stl=o.syncTaskList.split(",");
+                    if (o.syncTaskList.indexOf(SMBSYNC2_LIST_SEPARATOR)>0) {
+                        String[] stl=o.syncTaskList.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                         String sep="";
                         for(String stn:stl) {
                             if (ScheduleUtil.getSyncTask(mGp,stn)==null) {
                                 schedule_error=true;
                                 error_item_name=sep+stn;
-                                sep=",";
+                                sep="; ";
                             }
                         }
                     } else {
@@ -230,8 +233,7 @@ class AdapterScheduleList extends ArrayAdapter<ScheduleItem> {
                 } else {
                     holder.tv_error_info.setVisibility(TextView.GONE);
                 }
-                sync_prof = String.format(mContext.getString(R.string.msgs_scheduler_info_sync_selected_profile),
-                        o.syncTaskList);
+                sync_prof = String.format(mContext.getString(R.string.msgs_scheduler_info_sync_selected_profile), o.syncTaskList.replace(SMBSYNC2_LIST_SEPARATOR, "; "));
             }
             holder.tv_time_info.setText(time_info + " " + sync_prof);
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/Constants.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/Constants.java
@@ -114,6 +114,7 @@ public class Constants {
 
     public final static String SMBSYNC2_SERVICE_MEDIA_STATUS_CAHNGED="com.sentaroh.android."+APPLICATION_TAG+".ACTION_MEDIA_STATUS_CHANGED";
 
+    public final static String SMBSYNC2_LIST_SEPARATOR="|";//pipe char !
 
     public final static String SMBSYNC2_SYNC_REQUEST_ACTIVITY="ACTIVITY";
 	public final static String SMBSYNC2_SYNC_REQUEST_EXTERNAL="EXTERNAL";

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleItemEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleItemEditor.java
@@ -33,6 +33,7 @@ import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -62,6 +63,9 @@ import com.sentaroh.android.Utilities.ThemeColorList;
 import com.sentaroh.android.Utilities.Widget.CustomSpinnerAdapter;
 
 import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_LIST_SEPARATOR;
 
 public class ScheduleItemEditor {
 //    private CommonDialog commonDlg = null;
@@ -409,7 +413,7 @@ public class ScheduleItemEditor {
             btn_edit.setVisibility(Button.VISIBLE);//.setEnabled(true);
             tv_sync_prof.setVisibility(TextView.VISIBLE);//.setEnabled(true);
         }
-        tv_sync_prof.setText(mSched.syncTaskList);
+        tv_sync_prof.setText(mSched.syncTaskList.replace(SMBSYNC2_LIST_SEPARATOR, "; "));
 
         sp_sched_type.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override
@@ -595,7 +599,7 @@ public class ScheduleItemEditor {
                     @Override
                     public void positiveResponse(Context c, Object[] o) {
                         String prof_list = (String) o[0];
-                        tv_sync_prof.setText(prof_list);
+                        tv_sync_prof.setText(prof_list.replace(SMBSYNC2_LIST_SEPARATOR, "; "));
                         if (prof_list.equals("")) {
                             tv_msg.setText(mContext.getString(R.string.msgs_scheduler_edit_sync_prof_list_not_specified));
                             CommonDialog.setButtonEnabled(mActivity, btn_ok, false);
@@ -612,7 +616,7 @@ public class ScheduleItemEditor {
                     public void negativeResponse(Context c, Object[] o) {
                     }
                 });
-                editSyncTaskList(tv_sync_prof.getText().toString(), ntfy);
+                editSyncTaskList(tv_sync_prof.getText().toString().replace("; ", SMBSYNC2_LIST_SEPARATOR), ntfy);
             }
         });
 
@@ -675,13 +679,13 @@ public class ScheduleItemEditor {
 
     private String getNotExistsSyncTaskName(String task_list) {
         String error_item_name="";
-        if (task_list.indexOf(",")>0) {
-            String[] stl=task_list.split(",");
+        if (task_list.indexOf(SMBSYNC2_LIST_SEPARATOR)>0) {
+            String[] stl=task_list.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
             String sep="";
             for(String stn:stl) {
                 if (ScheduleUtil.getSyncTask(mGp,stn)==null) {
                     error_item_name=sep+stn;
-                    sep=",";
+                    sep="; ";
                 }
             }
         } else {
@@ -904,7 +908,7 @@ public class ScheduleItemEditor {
             sp.syncTaskList = "";
             sp.syncAutoSyncTask=true;
         } else {
-            sp.syncTaskList = tv_sync_prof.getText().toString();
+            sp.syncTaskList = tv_sync_prof.getText().toString().replace("; ", SMBSYNC2_LIST_SEPARATOR);
             sp.syncAutoSyncTask=false;
         }
 
@@ -931,6 +935,7 @@ public class ScheduleItemEditor {
     private void editSyncTaskList(final String prof_list, final NotifyEvent p_ntfy) {
         // カスタムダイアログの生成
         final Dialog dialog = new Dialog(mActivity, mGp.applicationTheme);
+        Log.v("I", "prof_list=" + prof_list);
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
         dialog.setCanceledOnTouchOutside(false);
         dialog.setContentView(R.layout.schedule_sync_edit_synclist_dlg);
@@ -978,7 +983,7 @@ public class ScheduleItemEditor {
                 for (int i = 0; i < lv_sync_list.getCount(); i++) {
                     if (lv_sync_list.isItemChecked(i)) {
                         n_prof_list = n_prof_list + sep + adapter.getItem(i).substring(1);
-                        sep = ",";
+                        sep = SMBSYNC2_LIST_SEPARATOR;
                     }
                 }
                 p_ntfy.notifyToListener(true, new Object[]{n_prof_list});
@@ -1008,7 +1013,7 @@ public class ScheduleItemEditor {
         }
 
         String[] pfa = null;
-        pfa = prof_list.split(",");
+        pfa = prof_list.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
         if (!prof_list.equals("")) {
             for (int i = 0; i < pfa.length; i++) {
                 setSelectedSyncList(pfa[i], lv, adapter);

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleUtil.java
@@ -27,6 +27,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.widget.TextView;
 
 import com.sentaroh.android.Utilities.StringUtil;
@@ -37,6 +38,9 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.regex.Pattern;
+
+import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_LIST_SEPARATOR;
 
 import static com.sentaroh.android.SMBSync2.ScheduleConstants.SCHEDULER_LAST_SCHEDULED_UTC_TIME_KEY;
 import static com.sentaroh.android.SMBSync2.ScheduleConstants.SCHEDULER_SCHEDULE_DAY_OF_THE_WEEK_KEY;
@@ -67,9 +71,14 @@ public class ScheduleUtil {
         String v3_data = prefs.getString(SCHEDULER_SCHEDULE_SAVED_DATA_V3, "-1");
         String v4_data = prefs.getString(SCHEDULER_SCHEDULE_SAVED_DATA_V4, "-1");
         String v5_data = prefs.getString(SCHEDULER_SCHEDULE_SAVED_DATA_V5, "-1");
+        //String v6_data = prefs.getString(SCHEDULER_SCHEDULE_SAVED_DATA_V6, "-1");
 //    	Log.v("","data="+v2_data);
+//        if (!v6_data.equals("-1")) {
+//            sl = buildScheduleListV6(gp, v6_data);
+//        } else
         if (!v5_data.equals("-1")) {
             sl = buildScheduleListV5(gp, v5_data);
+            //saveScheduleData(c, gp, sl);//save to v6
         } else if (!v4_data.equals("-1")) {
             sl = buildScheduleListV4(gp, v4_data);
         } else if (!v3_data.equals("-1")) {
@@ -290,6 +299,12 @@ public class ScheduleUtil {
                 if (sub_array[8].length() > 0)
                     si.scheduleLastExecTime = Long.valueOf(sub_array[8].replace("\u0000", ""));
                 si.syncTaskList = sub_array[9].replace("\u0000", "");
+                Log.v("I","loaded si.syncTaskList="+si.syncTaskList);
+                if (si.syncTaskList.contains(",")) {
+                    //Schedule List v5 doesn't support comma
+                    //si.syncTaskList = si.syncTaskList.replaceAll(",", SMBSYNC2_LIST_SEPARATOR);
+                    //will be saved later when returning from this method
+                }
                 si.syncGroupList = sub_array[10].replace("\u0000", "");
                 si.syncWifiOnBeforeStart = sub_array[11].replace("\u0000", "").equals("1") ? true : false;
                 si.syncWifiOffAfterEnd = sub_array[12].replace("\u0000", "").equals("1") ? true : false;
@@ -343,8 +358,8 @@ public class ScheduleUtil {
     final static public void removeSyncTaskFromSchedule(GlobalParameters gp, CommonUtilities cu, ArrayList<ScheduleItem> sl, String delete_task_name) {
         for (ScheduleItem si : sl) {
             if (!si.syncTaskList.equals("")&& si.syncTaskList.contains(delete_task_name)) {
-                if (si.syncTaskList.indexOf(",")>0) {//Multiple entry
-                    String[] task_list=si.syncTaskList.split(",");
+                if (si.syncTaskList.indexOf(SMBSYNC2_LIST_SEPARATOR)>0) {//Multiple entry
+                    String[] task_list=si.syncTaskList.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                     ArrayList<String>n_task_list=new ArrayList<String>();
                     if (task_list!=null) {
                         for(String stn:task_list) {
@@ -361,7 +376,7 @@ public class ScheduleUtil {
                             si.syncTaskList="";
                             for(String item:n_task_list) {
                                 si.syncTaskList+=sep+item;
-                                sep=",";
+                                sep=SMBSYNC2_LIST_SEPARATOR;
                             }
                         }
                     } else {
@@ -382,8 +397,8 @@ public class ScheduleUtil {
     final static public void renameSyncTaskFromSchedule(GlobalParameters gp, CommonUtilities cu, ArrayList<ScheduleItem> sl, String rename_task_name, String new_name) {
         for (ScheduleItem si : sl) {
             if (!si.syncTaskList.equals("") && si.syncTaskList.contains(rename_task_name)) {
-                if (si.syncTaskList.indexOf(",")>0) {//Multiple entry
-                    String[] task_list=si.syncTaskList.split(",");
+                if (si.syncTaskList.indexOf(SMBSYNC2_LIST_SEPARATOR)>0) {//Multiple entry
+                    String[] task_list=si.syncTaskList.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                     ArrayList<String>n_task_list=new ArrayList<String>();
                     if (task_list!=null) {
                         for(String stn:task_list) {
@@ -399,7 +414,7 @@ public class ScheduleUtil {
                     si.syncTaskList="";
                     for(String item:n_task_list) {
                         si.syncTaskList+=sep+item;
-                        sep=",";
+                        sep=SMBSYNC2_LIST_SEPARATOR;
                     }
                 } else {
                     if (si.syncTaskList.equals(rename_task_name)) {
@@ -692,8 +707,8 @@ public class ScheduleUtil {
                         //NOP
                     } else {
                         if (!si.syncTaskList.equals("")) {
-                            if (si.syncTaskList.indexOf(",")>0) {
-                                String[] stl=si.syncTaskList.split(",");
+                            if (si.syncTaskList.indexOf(SMBSYNC2_LIST_SEPARATOR)>0) {
+                                String[] stl=si.syncTaskList.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                                 for(String stn:stl) {
 //    /*debug*/                   cu.addDebugMsg(1,"I", "setSchedulerInfo findSyncTask1 name="+stn+", result="+getSyncTask(gp,stn));
                                     if (getSyncTask(gp,stn)==null) {

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncService.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncService.java
@@ -53,6 +53,7 @@ import com.sentaroh.android.Utilities.NotifyEvent.NotifyEventListener;
 import java.util.ArrayList;
 import java.util.Locale;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.regex.Pattern;
 
 import static com.sentaroh.android.SMBSync2.Constants.QUERY_SYNC_TASK_EXTRA_PARM_TASK_TYPE;
 import static com.sentaroh.android.SMBSync2.Constants.QUERY_SYNC_TASK_EXTRA_PARM_TASK_TYPE_ALL;
@@ -65,6 +66,7 @@ import static com.sentaroh.android.SMBSync2.Constants.REPLY_SYNC_TASK_EXTRA_PARM
 import static com.sentaroh.android.SMBSync2.Constants.REPLY_SYNC_TASK_INTENT;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_AUTO_SYNC_INTENT;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_EXTRA_PARM_SYNC_PROFILE;
+import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_LIST_SEPARATOR;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_NOTIFICATION_MESSAGE_WHEN_SYNC_ENDED_ALWAYS;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_NOTIFICATION_MESSAGE_WHEN_SYNC_ENDED_ERROR;
 import static com.sentaroh.android.SMBSync2.Constants.SMBSYNC2_NOTIFICATION_MESSAGE_WHEN_SYNC_ENDED_SUCCESS;
@@ -339,24 +341,24 @@ public class SyncService extends Service {
                 if (task_type.toLowerCase().equals(QUERY_SYNC_TASK_EXTRA_PARM_TASK_TYPE_TEST.toLowerCase())) {
                     if (sti.isSyncTestMode()) {
                         reply_list+=sep+sti.getSyncTaskName();
-                        sep=",";
+                        sep=SMBSYNC2_LIST_SEPARATOR;
                         reply_count++;
                     }
                 } else if (task_type.toLowerCase().equals(QUERY_SYNC_TASK_EXTRA_PARM_TASK_TYPE_AUTO.toLowerCase())) {
                     if (sti.isSyncTaskAuto()) {
                         reply_list+=sep+sti.getSyncTaskName();
-                        sep=",";
+                        sep=SMBSYNC2_LIST_SEPARATOR;
                         reply_count++;
                     }
                 } else if (task_type.toLowerCase().equals(QUERY_SYNC_TASK_EXTRA_PARM_TASK_TYPE_MANUAL.toLowerCase())) {
                     if (!sti.isSyncTaskAuto()) {
                         reply_list+=sep+sti.getSyncTaskName();
-                        sep=",";
+                        sep=SMBSYNC2_LIST_SEPARATOR;
                         reply_count++;
                     }
                 } else if (task_type.toLowerCase().equals(QUERY_SYNC_TASK_EXTRA_PARM_TASK_TYPE_ALL.toLowerCase())) {
                     reply_list+=sep+sti.getSyncTaskName();
-                    sep=",";
+                    sep=SMBSYNC2_LIST_SEPARATOR;
                     reply_count++;
                 }
             }
@@ -388,19 +390,19 @@ public class SyncService extends Service {
                         queueAutoSyncTask(SMBSYNC2_SYNC_REQUEST_SCHEDULE, si);
                     } else {
                         if (si.syncTaskList != null && si.syncTaskList.length() > 0) {
-                            String[] pl = si.syncTaskList.split(",");
+                            String[] pl = si.syncTaskList.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                             String n_tl = "", sep = "";
                             for (int i = 0; i < pl.length; i++) {
                                 if (getSyncTask(pl[i]) != null) {
                                     n_tl += sep + pl[i];
-                                    sep = ",";
+                                    sep = SMBSYNC2_LIST_SEPARATOR;
                                 } else {
                                     mUtil.addLogMsg("W",
                                             mContext.getString(R.string.msgs_svc_received_start_request_from_scheduler_task_not_found) + pl[i]);
                                 }
                             }
                             if (!n_tl.equals("")) {
-                                String[] n_pl = n_tl.split(",");
+                                String[] n_pl = n_tl.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                                 queueSpecificSyncTask(n_pl, SMBSYNC2_SYNC_REQUEST_SCHEDULE, si);
                             } else {
                                 mUtil.addLogMsg("E", mContext.getString(R.string.msgs_svc_received_start_request_from_scheduler_no_task_list));
@@ -430,7 +432,7 @@ public class SyncService extends Service {
             if (bundle.containsKey(SMBSYNC2_EXTRA_PARM_SYNC_PROFILE)) {
                 if (bundle.get(SMBSYNC2_EXTRA_PARM_SYNC_PROFILE).getClass().getSimpleName().equals("String")) {
                     String t_sp = bundle.getString(SMBSYNC2_EXTRA_PARM_SYNC_PROFILE);
-                    String[] sp = t_sp.split(",");
+                    String[] sp = t_sp.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
                     ArrayList<String> pl = new ArrayList<String>();
                     for (int i = 0; i < sp.length; i++) {
                         if (SyncTaskUtil.getSyncTaskByName(mGp.syncTaskList, sp[i]) != null) {
@@ -440,6 +442,10 @@ public class SyncService extends Service {
                                     mContext.getString(R.string.msgs_svc_received_start_request_from_external_task_not_found) + sp[i]);
                             NotificationUtil.showOngoingMsg(mGp, mUtil, 0,
                                     mContext.getString(R.string.msgs_svc_received_start_request_from_external_task_not_found) + sp[i]);
+                            if (t_sp.contains(",")) {
+                                //old script using "," separator ?
+                                mUtil.addLogMsg("W", "Task %s could not be found. It could be caused by using old ',' separator in script. Please replace it by pipe |");
+                            }
                         }
                     }
                     if (pl.size() > 0) {

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncService.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncService.java
@@ -432,7 +432,7 @@ public class SyncService extends Service {
             if (bundle.containsKey(SMBSYNC2_EXTRA_PARM_SYNC_PROFILE)) {
                 if (bundle.get(SMBSYNC2_EXTRA_PARM_SYNC_PROFILE).getClass().getSimpleName().equals("String")) {
                     String t_sp = bundle.getString(SMBSYNC2_EXTRA_PARM_SYNC_PROFILE);
-                    String[] sp = t_sp.split(Pattern.quote(SMBSYNC2_LIST_SEPARATOR));
+                    String[] sp = t_sp.split(",");
                     ArrayList<String> pl = new ArrayList<String>();
                     for (int i = 0; i < sp.length; i++) {
                         if (SyncTaskUtil.getSyncTaskByName(mGp.syncTaskList, sp[i]) != null) {
@@ -442,10 +442,6 @@ public class SyncService extends Service {
                                     mContext.getString(R.string.msgs_svc_received_start_request_from_external_task_not_found) + sp[i]);
                             NotificationUtil.showOngoingMsg(mGp, mUtil, 0,
                                     mContext.getString(R.string.msgs_svc_received_start_request_from_external_task_not_found) + sp[i]);
-                            if (t_sp.contains(",")) {
-                                //old script using "," separator ?
-                                mUtil.addLogMsg("W", "Task %s could not be found. It could be caused by using old ',' separator in script. Please replace it by pipe |");
-                            }
                         }
                     }
                     if (pl.size() > 0) {


### PR DESCRIPTION
Since I already did it, no reason to not share it
Here are the needed changes to support comma in schedule sync task list. The separator is a non valid char pipe "|" which can be changed via a constant. The display remains a "; " or you can be kept ", ". So user doesn't see the pipe char.

In the Schedule name edit dialog, we can add a check to disable using the Constant SMBSYNC2_LIST_SEPARATOR in the name

That way, maintenance in code is simpler and less error prone.

Missing part is just the simpler thing left: adding the v6 schedule list

Only real limitation is the external scripts using ","
A transparent alternative is to change separator to "pipe" but keep external scripts with "," when they are imported in SyncService.java part. However, it will not support scripts with "," in task name, like now by the way ! So All users won't notice any change, except on import of tasks with "," in name

You can even define SMBSYNC2_LIST_SEPARATOR = "," to not change anything, while being able to do in future.

Anyway, for me you can go with the simpler approach and disable "," for now. Just for info if you ever rewrite and clean it up to use this way or Array List

Best regards