### PR TITLE
Rebase on 2.35: Fix bug and enhance schedule sync task list view

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ActivityMain.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ActivityMain.java
@@ -4244,6 +4244,10 @@ public class ActivityMain extends AppCompatActivity {
                                 mGp.syncTaskAdapter.sort();
                                 SyncTaskUtil.saveSyncTaskListToFile(mGp, mContext, mUtil, false, "", "", mGp.syncTaskList, false);
                                 mGp.syncTaskAdapter.notifyDataSetChanged();
+                                //mUtil.addDebugMsg(2, "I", "c_pos="+c_pos + ", first v_pos="+mGp.syncTaskListView.getFirstVisiblePosition() + ", last v_pos="+mGp.syncTaskListView.getLastVisiblePosition() + ", tot="+mGp.syncTaskAdapter.getCount());
+                                int set_pos = c_pos < 3 ? c_pos:c_pos-3;//show the 2 items before (moved item is set at c_pos-1)
+                                //mGp.syncTaskListView.setSelection(c_pos-1);
+                                mGp.syncTaskListView.smoothScrollToPosition(set_pos);
 
                                 if (item.getSyncTaskPosition() == 0) {
                                     mContextSyncTaskViewMoveToUp.setVisibility(ImageButton.INVISIBLE);
@@ -4280,6 +4284,9 @@ public class ActivityMain extends AppCompatActivity {
                                 mGp.syncTaskAdapter.sort();
                                 SyncTaskUtil.saveSyncTaskListToFile(mGp, mContext, mUtil, false, "", "", mGp.syncTaskList, false);
                                 mGp.syncTaskAdapter.notifyDataSetChanged();
+                                int last_pos = mGp.syncTaskAdapter.getCount() - 1;
+                                int set_pos = c_pos > (last_pos - 3) ? c_pos:c_pos+3;//show next 2 items (moved item is set at c_pos+1)
+                                mGp.syncTaskListView.smoothScrollToPosition(set_pos);
 
                                 if (item.getSyncTaskPosition() == 0) {
                                     mContextSyncTaskViewMoveToUp.setVisibility(ImageButton.INVISIBLE);

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleItemEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleItemEditor.java
@@ -1081,28 +1081,35 @@ public class ScheduleItemEditor {
         return selected;
     }
 
-    //check if sync task "sel" that is defined in the schedule exists in the global sync task list
+    //check if sync task name "stn" that is defined in the schedule exists in the global sync task list
     //if not, add it to the schedule sync tasks list with a notification that it was deleted/renamed
-    private void setSelectedSyncList(String sel, ListView lv, SchedulerAdapterSyncList adapter) {
+    private void setSelectedSyncList(String stn, ListView lv, SchedulerAdapterSyncList adapter) {
         boolean found = false;
         for (int i = 0; i < adapter.getCount(); i++) {
             String prof_name = adapter.getItem(i).substring(1);
-            if (prof_name.compareToIgnoreCase(sel) == 0) {
+            if (prof_name.compareToIgnoreCase(stn) == 0) {
                 found = true;
 //				lv.setItemChecked(i, true);
                 break;
             }
         }
         if (!found) {
+            //add the non found sync task to schedule sync task list
+            boolean added = false;
             for (int i = 0; i < adapter.getCount(); i++) {
                 String prof_name = adapter.getItem(i).substring(1);
-                if (prof_name.compareToIgnoreCase(sel) > 0) {
-                    adapter.insert(SYNC_TASK_NOT_FOUND + sel, i + 1);
-                    adapter.notifyDataSetChanged();
+                if (prof_name.compareToIgnoreCase(stn) < 0) {
+                    adapter.insert(SYNC_TASK_NOT_FOUND + stn, i + 1);
 //					lv.setItemChecked(i+1, true);
+                    added = true;
                     break;
                 }
             }
+            if (!added) {
+                //it is the shortest task name in the list, add it to the top of the list
+                adapter.insert(SYNC_TASK_NOT_FOUND + stn, 0);
+            }
+            adapter.notifyDataSetChanged();
         }
     }
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleItemEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/ScheduleItemEditor.java
@@ -1386,10 +1386,14 @@ public class ScheduleItemEditor {
 
         @Override
         public boolean isEnabled(int position) {
+            if (lv_sync_list == null) {
+                //shouldn't happen if entered through schedule editor
+                return false;
+            }
             View child  = lv_sync_list.getChildAt(position - lv_sync_list.getFirstVisiblePosition());
             if (child == null) {
                 mUtil.addDebugMsg(1, "I", "child=null, " + "position="+position + ", getFirstVisiblePosition="+lv_sync_list.getFirstVisiblePosition());
-                return true;//false ?
+                return false;
             }
 
             //mUtil.addDebugMsg(1, "I", "first visible item=" + lv_sync_list.getFirstVisiblePosition() + ", position=" + position);


### PR DESCRIPTION
- fixes schedules cannot be edited caused by last commit https://github.com/Sentaroh/SMBSync2/commit/1686e1c4fa0ced4bb02563ce307f3fb82d311d5a
- enhancements:
  + when sync task is invalid and is defined in the schedule: show it checked + normal highlight + can be unchecked to fix the schedule sync list and save it. Once unchecked, it is greyed + disabled to not allow selection again
  + when sync task is invalid and not existing in the schedule: show it unchecked + greyed + not selectable (disabled)
  + sync tasks not in error, can be checked/unchecked
  + properly enable/disable Save button in the Schedule Sync List
- fix schedule sync task cannot be edited in some cases
this bug was present since a long time
- fix move sync task up/down view