### PR TITLE
Fix bugs in result_log file names and sync task file name

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/CommonUtilities.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/CommonUtilities.java
@@ -898,6 +898,9 @@ public final class CommonUtilities {
         return hl;
     }
 
+    //source: https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    final private static String[] SMBSYNC2_PROF_SYNC_LOG_FILE_INVALID_CHARS=new String[]{"<", ">", ":", "\"", "/", "\\", "|", "?", "*", " "};
+    final private static String[] SMBSYNC2_PROF_SYNC_LOG_FILE_INVALID_CHARS_TAIL=new String[]{".", " "};
     final public String createSyncResultFilePath(String syncProfName) {
         String dir = mGp.settingMgtFileDir + "/result_log";
         File tlf = new File(dir);
@@ -906,9 +909,23 @@ public final class CommonUtilities {
 //            Log.v("","create="+create);
         }
 //		Log.v("","fp="+dir+", exists="+tlf.exists());
-        String dt = StringUtil.convDateTimeTo_YearMonthDayHourMinSec(System.currentTimeMillis());
-        String fn = "result_" + syncProfName + "_" + dt + ".txt";
-        String fp = dir + "/" + fn.replaceAll("/", "-").replaceAll(":", "").replaceAll(" ", "_");
+        String dt = StringUtil.convDateTimeTo_YearMonthDayHourMinSec(System.currentTimeMillis()).replaceAll("/", "-").replaceAll(":", "").replaceAll(" ", "_");
+        String fn = "result_" + syncProfName;
+        if ((fn.length() + dt.length()) > 250) {//250 = 255-5 for "_" and ".txt" appended at end of file name
+            fn = fn.substring(0, 250 - dt.length());
+        }
+
+        fn += "_" + dt;
+        for(String invalid_str:SMBSYNC2_PROF_SYNC_LOG_FILE_INVALID_CHARS) {
+            fn = fn.replaceAll(Pattern.quote(invalid_str), "_");
+        }
+        for(String invalid_str:SMBSYNC2_PROF_SYNC_LOG_FILE_INVALID_CHARS_TAIL) {
+            if (fn.startsWith(invalid_str))
+                fn = fn.replaceFirst(Pattern.quote(invalid_str), "_");
+        }
+
+        fn+=".txt";
+        String fp = dir + "/" + fn;
         return fp;
     }
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/Constants.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/Constants.java
@@ -138,6 +138,7 @@ public class Constants {
     final public static String[] SMBSYNC2_PROF_FILTER_FILE_INVALID_CHARS=new String[]{"\"", ":", ">", "<", "|", "//", "**", "\\"};
     final public static String[] SMBSYNC2_PROF_FILTER_DIR_INVALID_CHARS=new String[] {"\"", ":", ">", "<", "|", "//", "**"};
     final public static String[] SYNC_TASK_NAME_UNUSABLE_CHARACTER=new String[]{","};
+    final public static int SYNC_TASK_NAME_MAX_LENGTH=150;
 
     final public static String SYNC_TASK_LIST_SEPARATOR=",";
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -4113,7 +4113,7 @@ public class SyncTaskUtil {
     //WARNING: on early load of Sync settings from file, gp.syncTaskAdapter/syncTaskList are not init (ActivityMain and SyncService)
     //         check for duplicates will fail if we pass GlobalParameters as arg
     static public String isValidSyncTaskName(Context c, ArrayList<SyncTaskItem> stl, String t_name, boolean checkDup, boolean showAllError) {
-        String result = "", invalid_length_msg="", invalid_chars_msg="", dup_msg="", sep="";
+        String result = "", sep="";
         if (t_name.length() > 0) {
             result = hasSyncTaskNameInvalidLength(c, t_name);
             if (!result.equals("")) sep = "\n";


### PR DESCRIPTION
- result_log txt file cannot have invalid characters else it will fail to sync to or to be saved to FAT32/NTFS or any windows system
This patch preserves the useful ability to name sync tasks freely while ensuring the result.log file is valid
- fix result_log file name length could exceed 255 chars
- ensure sync task name global length cannot be longer than 150 chars to fix a bug in the EditSyncTask GUI. Also, 150 chars seems more than enough for a sync task name

Note: another patch is needed to fix the root cause of the GUI bug in EditSyncTask when the name is too long