### PR TITLE
Added support for dng files

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/Constants.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/Constants.java
@@ -186,13 +186,13 @@ public class Constants {
 			new String[]{"*.aac","*.aif", "*.aifc", "*.aiff", "*.flac", "*.kar", "*.m3u", "*.m4a", "*.mid", "*.midi", "*.mp2",
 							"*.mp3", "*.mpga", "*.ogg", "*.ra", "*.ram", "*.wav"};
 	public static final String[] SYNC_FILE_TYPE_IMAGE=
-			new String[]{"*.bmp", "*.cgm", "*.djv", "*.djvu", "*.gif", "*.ico", "*.ief", "*.jpe", "*.jpeg", "*.jpg", "*.pbm",
+			new String[]{"*.bmp", "*.cgm", "*.djv", "*.djvu", "*.dng", "*.gif", "*.ico", "*.ief", "*.jpe", "*.jpeg", "*.jpg", "*.pbm",
 						"*.pgm", "*.png", "*.pnm", "*.ppm", "*.ras", "*.rgb", "*.svg", "*.tif", "*.tiff", "*.wbmp", "*.xbm", 
 						"*.xpm", "*.xwd"};
 	public static final String[] SYNC_FILE_TYPE_VIDEO=
 			new String[]{"*.avi", "*.m4u", "*.mov", "*.mp4", "*.movie", "*.mpe", "*.mpeg", "*.mpg", "*.mxu", "*.qt", "*.wmv"};
 
     public static final String[] ARCHIVE_FILE_TYPE=
-            new String[]{"gif", "jpg", "jpeg", "jpe", "png", "mp4", "mov"};
+            new String[]{"dng", "gif", "jpg", "jpeg", "jpe", "png", "mp4", "mov"};
 
 }

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/GlobalParameters.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/GlobalParameters.java
@@ -160,7 +160,7 @@ public class GlobalParameters extends CommonGlobalParms {
 
     public String settingNoCompressFileType = DEFAULT_NOCOMPRESS_FILE_TYPE;
     static final public String DEFAULT_NOCOMPRESS_FILE_TYPE =
-            "aac;apk;avi;gif;ico;gz;jar;jpe;jpeg;jpg;m3u;m4a;m4u;mov;movie;mp2;mp3;mpe;mpeg;mpg;mpga;png;qt;ra;ram;svg;tgz;wmv;zip;";
+            "aac;apk;avi;dng;gif;ico;gz;jar;jpe;jpeg;jpg;m3u;m4a;m4u;mov;movie;mp2;mp3;mpe;mpeg;mpg;mpga;png;qt;ra;ram;svg;tgz;wmv;zip;";
 
     public boolean settingSupressAppSpecifiDirWarning = false;
     public boolean settingSupressLocationServiceWarning =false;

--- a/SMBSync2/src/main/res/layout-land/edit_sync_folder_dlg_archive.xml
+++ b/SMBSync2/src/main/res/layout-land/edit_sync_folder_dlg_archive.xml
@@ -43,7 +43,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="30dp"
-                android:text="*.gif, *.jpg, *.png, *.mp4, *.mov"
+                android:text="*.dng, *.gif, *.jpg, *.png, *.mp4, *.mov"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
             <!--android:checkMark="?android:attr/listChoiceIndicatorMultiple"-->
 

--- a/SMBSync2/src/main/res/layout-large/edit_sync_folder_dlg_archive.xml
+++ b/SMBSync2/src/main/res/layout-large/edit_sync_folder_dlg_archive.xml
@@ -46,7 +46,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="30dp"
-                android:text="*.gif, *.jpg, *.png, *.mp4, *.mov"
+                android:text="*.dng, *.gif, *.jpg, *.png, *.mp4, *.mov"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
             <!--android:checkMark="?android:attr/listChoiceIndicatorMultiple"-->
 


### PR DESCRIPTION
I thought it would be great to be able to sync also raw files, which many phones support these days.

I checked that the current exif data retrieval works with both Adobe_DNG_Converter-generated files and with native dng photos of my Oneplus3, so I simply added the dng extension to the image supported.
I think this probably will also work with other raw formats, but I have no other phones to try.
 