### PR TITLE
2021.02.06 fix edittext size filter

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -5558,11 +5558,11 @@ public class SyncTaskEditor extends DialogFragment {
                     if (et_file_date_value.getText().length()==0) {
                         result=mContext.getString(R.string.msgs_task_sync_task_sync_file_date_filter_error_update_date_not_specified);
                         error_detected = true;
-                    } else if (sel.equals(SyncTaskItem.FILTER_FILE_DATE_TYPE_OLDER) && Integer.parseInt(et_file_date_value.getText().toString())==0) {
-                        result=mContext.getString(R.string.msgs_task_sync_task_sync_file_date_filter_error_update_date_must_be_greater_than_0);
-                        error_detected = true;
                     } else if (et_file_date_value.getText().length()>3) {
                         result=mContext.getString(R.string.msgs_task_sync_task_sync_file_date_filter_error_update_date_must_be_less_3_digit);
+                        error_detected = true;
+                    } else if (!sel.equals(SyncTaskItem.FILTER_FILE_DATE_TYPE_NONE) && Integer.parseInt(et_file_date_value.getText().toString())==0) {
+                        result=mContext.getString(R.string.msgs_task_sync_task_sync_file_date_filter_error_update_date_must_be_greater_than_0);
                         error_detected = true;
                     }
                 }

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskEditor.java
@@ -5543,8 +5543,7 @@ public class SyncTaskEditor extends DialogFragment {
                     if (et_file_size_value.getText().length()==0) {
                         result=mContext.getString(R.string.msgs_task_sync_task_sync_file_size_filter_error_file_size_not_specified);
                         error_detected = true;
-                    } else if (et_file_size_value.getText().length()>=5) {
-                        et_file_size_value.getText().delete(4,5);
+                    } else if (et_file_size_value.getText().length()>5) {
                         result=mContext.getString(R.string.msgs_task_sync_task_sync_file_size_filter_error_file_size_must_be_less_5_digit);
                         error_detected = true;
                     } else if (SyncTaskItem.getSyncFilterFileSizeTypeByIndex(sp_file_size_type.getSelectedItemPosition()).equals(SyncTaskItem.FILTER_FILE_SIZE_TYPE_LT)) {

--- a/SMBSync2/src/main/res/layout/edit_sync_task_dlg_filter.xml
+++ b/SMBSync2/src/main/res/layout/edit_sync_task_dlg_filter.xml
@@ -112,7 +112,7 @@
                         android:layout_width="80dp"
                         android:layout_height="wrap_content"
                         android:inputType="number"
-                        android:maxLength="6"
+                        android:maxLength="5"
                         android:hint="@string/msgs_task_sync_task_sync_file_size_size_hint"
                         android:layout_gravity="center_vertical"/>
                 </android.support.design.widget.TextInputLayout>
@@ -157,7 +157,7 @@
                         android:layout_gravity="center_vertical"
                         android:hint="@string/msgs_task_sync_task_sync_file_date_hint"
                         android:inputType="number"
-                        android:maxLength="4" />
+                        android:maxLength="3" />
                 </android.support.design.widget.TextInputLayout>
             </LinearLayout>
             <include layout="@layout/divider_line1" />


### PR DESCRIPTION
- Allow size filter of 5 digits
- Fix error was displayed while the size filter had the proper length: when size was 5 digits, last digit was deleted but we were stuck with the error message
- always check date field value size before attempting to parse the text field as an integer
- fix the date value could be set to 0 when spinner was set to "Newer than"
- Optional: limit size/date text fields length and avoid error messages