### PR TITLE
Fix size filter defaults

### DIFF
--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskItem.java
@@ -513,9 +513,8 @@ class SyncTaskItem implements Serializable, Cloneable {
     public boolean isSyncOptionIgnoreFileSize0ByteFile() {return syncSyncOptionIgnoreFileSize0ByteFile;}
     public void setSyncOptionIgnoreFileSize0ByteFile(boolean p) {syncSyncOptionIgnoreFileSize0ByteFile = p;}
 
-    static final public String FILTER_FILE_SIZE_VALUE_DEFAULT_GREATER_THAN = "0";
-    static final public String FILTER_FILE_SIZE_VALUE_DEFAULT_LESS_THAN = "1";
-    private String syncFilterFileSizeValue = FILTER_FILE_SIZE_VALUE_DEFAULT_GREATER_THAN;
+    static final public String FILTER_FILE_SIZE_VALUE_DEFAULT= "0";
+    private String syncFilterFileSizeValue = FILTER_FILE_SIZE_VALUE_DEFAULT;
     public String getSyncFilterFileSizeValue() {return syncFilterFileSizeValue;}
     public void setSyncFilterFileSizeValue(String p) {syncFilterFileSizeValue = p;}
 

--- a/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
+++ b/SMBSync2/src/main/java/com/sentaroh/android/SMBSync2/SyncTaskUtil.java
@@ -7927,24 +7927,15 @@ public class SyncTaskUtil {
             }
 
             if (!parm[97].equals("") && !parm[97].equals("end")) {
-                if (stli.getSyncFilterFileSizeType().equals(SyncTaskItem.FILTER_FILE_SIZE_TYPE_DEFAULT)) {
+                //if (stli.getSyncFilterFileSizeType().equals(SyncTaskItem.FILTER_FILE_SIZE_TYPE_DEFAULT)) {
                     //NOP
-                } else if (stli.getSyncFilterFileSizeType().equals(SyncTaskItem.FILTER_FILE_SIZE_TYPE_LESS_THAN)) {
-                    if (parm[97].length() <= 5 && TextUtils.isDigitsOnly(parm[97]) && Integer.parseInt(parm[97]) > 0) { //max 5 digits allowed and value > 1
-                        stli.setSyncFilterFileSizeValue(parm[97]);
-                    } else {
-                        stli.setSyncFilterFileSizeValue(SyncTaskItem.FILTER_FILE_SIZE_VALUE_DEFAULT_LESS_THAN);
-                        stli.setSyncFilterFileSizeType(SyncTaskItem.FILTER_FILE_SIZE_TYPE_DEFAULT);
-                        putTaskListValueErrorMessage(util, "Filter File Size Value", SyncTaskItem.FILTER_FILE_SIZE_VALUE_DEFAULT_LESS_THAN);
-                    }
-                } else if (stli.getSyncFilterFileSizeType().equals(SyncTaskItem.FILTER_FILE_SIZE_TYPE_GREATER_THAN)) {
-                    if (parm[97].length() <= 5 && TextUtils.isDigitsOnly(parm[97]) && Integer.parseInt(parm[97]) >= 0) { //max 5 digits allowed and value >= 0
-                        stli.setSyncFilterFileSizeValue(parm[97]);
-                    } else {
-                        stli.setSyncFilterFileSizeValue(SyncTaskItem.FILTER_FILE_SIZE_VALUE_DEFAULT_GREATER_THAN);
-                        stli.setSyncFilterFileSizeType(SyncTaskItem.FILTER_FILE_SIZE_TYPE_DEFAULT);
-                        putTaskListValueErrorMessage(util, "Filter File Size Value", SyncTaskItem.FILTER_FILE_SIZE_VALUE_DEFAULT_GREATER_THAN);
-                    }
+                //} else
+                if (parm[97].length() <= 5 && TextUtils.isDigitsOnly(parm[97]) && Integer.parseInt(parm[97]) > 0) { //max 5 digits allowed and value > 1
+                    stli.setSyncFilterFileSizeValue(parm[97]);
+                } else {
+                    stli.setSyncFilterFileSizeValue(SyncTaskItem.FILTER_FILE_SIZE_VALUE_DEFAULT);
+                    stli.setSyncFilterFileSizeType(SyncTaskItem.FILTER_FILE_SIZE_TYPE_DEFAULT);
+                    putTaskListValueErrorMessage(util, "Filter File Size Value", SyncTaskItem.FILTER_FILE_SIZE_VALUE_DEFAULT);
                 }
             }
 


### PR DESCRIPTION
- Filter size default default value is always 0 for Greater or Lower Than filters (and not 1 on corrupted settings file and 0 for other cases)
- Properly save the last set filter size value when filter is enabled/disabled and application restarted. This fixes a bug where the value was reset to 0 in that case and not saved like other app settings.